### PR TITLE
Upgrade to Spark 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,34 +12,36 @@ javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
 parallelExecution in test := false
 
-libraryDependencies ++= Seq("org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
-	"org.apache.spark" %% "spark-sql" % "1.6.0" % "provided",
-	"com.aerospike" % "aerospike-client" % "3.2.4",
-	"com.aerospike" % "aerospike-helper-java" % "1.0.6",
-	"org.scalatest" %% "scalatest" % "2.2.1" % "test")
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core"            % "1.6.0" % Provided,
+  "org.apache.spark" %% "spark-sql"             % "1.6.0" % Provided,
+  "com.aerospike"    %  "aerospike-client"      % "3.2.4",
+  "com.aerospike"    %  "aerospike-helper-java" % "1.0.6",
+  "org.scalatest"    %% "scalatest"             % "2.2.1" % Test
+)
 
 resolvers ++= Seq("Local Maven" at Path.userHome.asFile.toURI.toURL + ".m2/repository")
 
 assemblyMergeStrategy in assembly := {
-    case x if Assembly.isConfigFile(x) =>
-      MergeStrategy.concat
-    case PathList(ps @ _*) if Assembly.isReadme(ps.last) || Assembly.isLicenseFile(ps.last) =>
-      MergeStrategy.rename
-   case PathList("META-INF", "maven","com.aerospike","aerospike-client", "pom.properties") =>
-      MergeStrategy.discard
-    case PathList("META-INF", xs @ _*) =>
-      (xs map {_.toLowerCase}) match {
-        case ("manifest.mf" :: Nil) | ("index.list" :: Nil) | ("dependencies" :: Nil) =>
-          MergeStrategy.discard
-        case ps @ (x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
-          MergeStrategy.discard
-        case "plexus" :: xs =>
-          MergeStrategy.discard
-        case "services" :: xs =>
-          MergeStrategy.filterDistinctLines
-        case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
-          MergeStrategy.filterDistinctLines
-        case _ => MergeStrategy.deduplicate
-      }
-   case _ => MergeStrategy.first
+  case x if Assembly.isConfigFile(x) =>
+    MergeStrategy.concat
+  case PathList(ps @ _*) if Assembly.isReadme(ps.last) || Assembly.isLicenseFile(ps.last) =>
+    MergeStrategy.rename
+  case PathList("META-INF", "maven","com.aerospike","aerospike-client", "pom.properties") =>
+    MergeStrategy.discard
+  case PathList("META-INF", xs @ _*) =>
+    (xs map {_.toLowerCase}) match {
+      case ("manifest.mf" :: Nil) | ("index.list" :: Nil) | ("dependencies" :: Nil) =>
+        MergeStrategy.discard
+      case ps @ (x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
+        MergeStrategy.discard
+      case "plexus" :: xs =>
+        MergeStrategy.discard
+      case "services" :: xs =>
+        MergeStrategy.filterDistinctLines
+      case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
+        MergeStrategy.filterDistinctLines
+      case _ => MergeStrategy.deduplicate
+    }
+  case _ => MergeStrategy.first
 }

--- a/build.sbt
+++ b/build.sbt
@@ -30,14 +30,14 @@ assemblyMergeStrategy in assembly := {
   case PathList("META-INF", "maven","com.aerospike","aerospike-client", "pom.properties") =>
     MergeStrategy.discard
   case PathList("META-INF", xs @ _*) =>
-    (xs map {_.toLowerCase}) match {
+    xs.map(_.toLowerCase) match {
       case ("manifest.mf" :: Nil) | ("index.list" :: Nil) | ("dependencies" :: Nil) =>
         MergeStrategy.discard
-      case ps @ (x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
+      case ps @ (x :: _) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
         MergeStrategy.discard
-      case "plexus" :: xs =>
+      case "plexus" :: _ =>
         MergeStrategy.discard
-      case "services" :: xs =>
+      case "services" :: _ =>
         MergeStrategy.filterDistinctLines
       case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
         MergeStrategy.filterDistinctLines

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ libraryDependencies ++= Seq(
 
 resolvers ++= Seq("Local Maven" at Path.userHome.asFile.toURI.toURL + ".m2/repository")
 
+cancelable in Global := true
+
 assemblyMergeStrategy in assembly := {
   case x if Assembly.isConfigFile(x) =>
     MergeStrategy.concat

--- a/build.sbt
+++ b/build.sbt
@@ -6,18 +6,23 @@ version := "1.1.5"
 
 organization := "com.aerospike"
 
-scalaVersion := "2.10.6"
+crossScalaVersions := Seq("2.10.6", "2.11.8")
+
+scalaVersion := "2.11.8"
 
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
 parallelExecution in test := false
 
+fork in test := true
+
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core"            % "1.6.0" % Provided,
-  "org.apache.spark" %% "spark-sql"             % "1.6.0" % Provided,
-  "com.aerospike"    %  "aerospike-client"      % "3.2.4",
-  "com.aerospike"    %  "aerospike-helper-java" % "1.0.6",
-  "org.scalatest"    %% "scalatest"             % "2.2.1" % Test
+  "org.apache.spark"           %% "spark-core"            % "2.0.0" % Provided,
+  "org.apache.spark"           %% "spark-sql"             % "2.0.0" % Provided,
+  "com.aerospike"              %  "aerospike-client"      % "3.2.4",
+  "com.aerospike"              %  "aerospike-helper-java" % "1.0.6",
+  "com.typesafe.scala-logging" %% "scala-logging-slf4j"   % "2.1.2",
+  "org.scalatest"              %% "scalatest"             % "2.2.1" % Test
 )
 
 resolvers ++= Seq("Local Maven" at Path.userHome.asFile.toURI.toURL + ".m2/repository")

--- a/src/main/scala/com/aerospike/spark/sql/AerospikeConfig.scala
+++ b/src/main/scala/com/aerospike/spark/sql/AerospikeConfig.scala
@@ -4,173 +4,173 @@ import scala.collection.immutable.Map
 import com.aerospike.client.policy.CommitLevel
 import com.aerospike.client.policy.GenerationPolicy
 /**
- * this class is a container for the properties used during the
- * the read and save functions 
- */
+  * this class is a container for the properties used during the
+  * the read and save functions
+  */
 class AerospikeConfig private(val properties: Map[String, Any]) extends Serializable {
 
-	def get(key: String): Any =
+  def get(key: String): Any =
     properties.get(key.toLowerCase()).getOrElse(notFound(key))
 
   def getIfNotEmpty(key: String, defaultVal: Any): Any = {
     val proposed = properties.get(key.toLowerCase()).getOrElse(defaultVal)
-    match {
+      match {
       case n: Number => n.longValue
       case b: Boolean => if(b) 1 else 0
-      case s: String  => if (s.isEmpty()) defaultVal else s 
+      case s: String  => if (s.isEmpty()) defaultVal else s
       case _ => null
     }
   }
-	
-	def namespace(): String = {
-	  get(AerospikeConfig.NameSpace).asInstanceOf[String]
-	}
 
-	def set(): String = {
-	  get(AerospikeConfig.SetName).asInstanceOf[String]
-	}
+  def namespace(): String = {
+    get(AerospikeConfig.NameSpace).asInstanceOf[String]
+  }
 
-	def seedHost(): String = {
-	  get(AerospikeConfig.SeedHost).asInstanceOf[String]
-	}
+  def set(): String = {
+    get(AerospikeConfig.SetName).asInstanceOf[String]
+  }
 
-	def port(): Int = {
-	  get(AerospikeConfig.Port).asInstanceOf[Int]
-	}
-	
-	def schemaScan(): Int = {
-	  get(AerospikeConfig.SchemaScan).asInstanceOf[Int]
-	}
-	
-	def timeOut(): Int = {
-	  get(AerospikeConfig.TimeOut).asInstanceOf[Int]
-	}
-	def keyColumn(): String = {
-	  get(AerospikeConfig.KeyColumn).asInstanceOf[String]
-	}
-	
-	def digestColumn(): String = {
-	  get(AerospikeConfig.DigestColumn).asInstanceOf[String]
-	}
-	
-	def expiryColumn(): String = {
-	  get(AerospikeConfig.ExpiryColumn).asInstanceOf[String]
-	}
-	
-	def generationColumn(): String = {
-	  get(AerospikeConfig.GenerationColumn).asInstanceOf[String]
-	}
-	
-	def ttlColumn(): String = {
-	  get(AerospikeConfig.TTLColumn).asInstanceOf[String]
-	}
-	
-	
-	override def toString(): String = {
-	  var buff = new StringBuffer("[")
-	  properties.map(f => {
-	    buff.append("{")
-	    buff.append(f._1)
-	    buff.append("=")
-	    buff.append(f._2)
-	    buff.append("}")
-	  })
-	  buff.append("]")
-	  buff.toString()
-	}
-	
+  def seedHost(): String = {
+    get(AerospikeConfig.SeedHost).asInstanceOf[String]
+  }
+
+  def port(): Int = {
+    get(AerospikeConfig.Port).asInstanceOf[Int]
+  }
+
+  def schemaScan(): Int = {
+    get(AerospikeConfig.SchemaScan).asInstanceOf[Int]
+  }
+
+  def timeOut(): Int = {
+    get(AerospikeConfig.TimeOut).asInstanceOf[Int]
+  }
+  def keyColumn(): String = {
+    get(AerospikeConfig.KeyColumn).asInstanceOf[String]
+  }
+
+  def digestColumn(): String = {
+    get(AerospikeConfig.DigestColumn).asInstanceOf[String]
+  }
+
+  def expiryColumn(): String = {
+    get(AerospikeConfig.ExpiryColumn).asInstanceOf[String]
+  }
+
+  def generationColumn(): String = {
+    get(AerospikeConfig.GenerationColumn).asInstanceOf[String]
+  }
+
+  def ttlColumn(): String = {
+    get(AerospikeConfig.TTLColumn).asInstanceOf[String]
+  }
+
+
+  override def toString(): String = {
+    var buff = new StringBuffer("[")
+    properties.map(f => {
+      buff.append("{")
+      buff.append(f._1)
+      buff.append("=")
+      buff.append(f._2)
+      buff.append("}")
+    })
+    buff.append("]")
+    buff.toString()
+  }
+
   private def notFound[T](key: String): T =
     throw new IllegalStateException(s"Config item $key not specified")
-  
-  
+
+
 }
 
 object AerospikeConfig {
-  
-	private val defaultValues = scala.collection.mutable.Map[String, Any](
-	        AerospikeConfig.SeedHost -> "127.0.0.1", 
-	        AerospikeConfig.Port -> 3000,
-	        AerospikeConfig.SchemaScan -> 100,
-	        AerospikeConfig.TimeOut -> 1000,
-	        AerospikeConfig.NameSpace -> "test",
-	        AerospikeConfig.KeyColumn -> "__key",
-	        AerospikeConfig.DigestColumn -> "__digest",
-	        AerospikeConfig.ExpiryColumn -> "__expiry",
-	        AerospikeConfig.GenerationColumn -> "__generation",
-	        AerospikeConfig.TTLColumn -> "__ttl")
-	        
-	final val DEFAULT_READ_PURPOSE = "spark_read"
-	final val DEFAULT_WRITE_PURPOSE = "spark_write"
 
-	val SeedHost = "aerospike.seedhost"
-	defineProperty(SeedHost, "127.0.0.1")
+  private val defaultValues = scala.collection.mutable.Map[String, Any](
+    AerospikeConfig.SeedHost -> "127.0.0.1",
+    AerospikeConfig.Port -> 3000,
+    AerospikeConfig.SchemaScan -> 100,
+    AerospikeConfig.TimeOut -> 1000,
+    AerospikeConfig.NameSpace -> "test",
+    AerospikeConfig.KeyColumn -> "__key",
+    AerospikeConfig.DigestColumn -> "__digest",
+    AerospikeConfig.ExpiryColumn -> "__expiry",
+    AerospikeConfig.GenerationColumn -> "__generation",
+    AerospikeConfig.TTLColumn -> "__ttl")
 
-	val Port = "aerospike.port"
-	defineProperty(Port, 3000)
+  final val DEFAULT_READ_PURPOSE = "spark_read"
+  final val DEFAULT_WRITE_PURPOSE = "spark_write"
 
-	val TimeOut = "aerospike.timeout"
-	defineProperty(TimeOut, 1000)
-	
-	val sendKey = "aerospike.sendKey"
-	defineProperty(sendKey, false)
-	
-	val commitLevel = "aerospike.commitLevel"
-	defineProperty(commitLevel, CommitLevel.COMMIT_ALL)
-	
-	val generationPolicy = "aerospike.generationPolicy"
-	defineProperty(generationPolicy, GenerationPolicy.NONE)
-	
-	val NameSpace = "aerospike.namespace"
-	defineProperty(NameSpace, "test")
-	
-	val SetName = "aerospike.set"
-	defineProperty(SetName, null)
-	
-	val UpdateByKey = "aerospike.updateByKey"
-	defineProperty(UpdateByKey, null)
-	
-	val UpdateByDigest = "aerospike.updateByDigest"
-	defineProperty(UpdateByDigest, null)
-	
-	val SchemaScan = "aerospike.schema.scan"
-	defineProperty(SchemaScan, 100)
-	
-	val KeyColumn = "aerospike.keyColumn"
-	defineProperty(KeyColumn, "__key")
+  val SeedHost = "aerospike.seedhost"
+  defineProperty(SeedHost, "127.0.0.1")
 
-	val DigestColumn = "aerospike.digestColumn"
-	defineProperty(DigestColumn, "__digest")
+  val Port = "aerospike.port"
+  defineProperty(Port, 3000)
 
-	val ExpiryColumn = "aerospike.expiryColumn"
-	defineProperty(ExpiryColumn, "__expiry")
+  val TimeOut = "aerospike.timeout"
+  defineProperty(TimeOut, 1000)
 
-	val GenerationColumn = "aerospike.generationColumn"
-	defineProperty(GenerationColumn, "__generation")
+  val sendKey = "aerospike.sendKey"
+  defineProperty(sendKey, false)
 
-	val TTLColumn = "aerospike.ttlColumn"
-	defineProperty(TTLColumn, "__ttl")
+  val commitLevel = "aerospike.commitLevel"
+  defineProperty(commitLevel, CommitLevel.COMMIT_ALL)
+
+  val generationPolicy = "aerospike.generationPolicy"
+  defineProperty(generationPolicy, GenerationPolicy.NONE)
+
+  val NameSpace = "aerospike.namespace"
+  defineProperty(NameSpace, "test")
+
+  val SetName = "aerospike.set"
+  defineProperty(SetName, null)
+
+  val UpdateByKey = "aerospike.updateByKey"
+  defineProperty(UpdateByKey, null)
+
+  val UpdateByDigest = "aerospike.updateByDigest"
+  defineProperty(UpdateByDigest, null)
+
+  val SchemaScan = "aerospike.schema.scan"
+  defineProperty(SchemaScan, 100)
+
+  val KeyColumn = "aerospike.keyColumn"
+  defineProperty(KeyColumn, "__key")
+
+  val DigestColumn = "aerospike.digestColumn"
+  defineProperty(DigestColumn, "__digest")
+
+  val ExpiryColumn = "aerospike.expiryColumn"
+  defineProperty(ExpiryColumn, "__expiry")
+
+  val GenerationColumn = "aerospike.generationColumn"
+  defineProperty(GenerationColumn, "__generation")
+
+  val TTLColumn = "aerospike.ttlColumn"
+  defineProperty(TTLColumn, "__ttl")
 
 
-	private def defineProperty(key: String, defaultValue: Any) : Unit = {
-		val lowerKey = key.toLowerCase()
-		if(defaultValues.contains(lowerKey))
-				sys.error(s"Config property already defined for key : $key")
-		else
-			defaultValues.put(lowerKey, defaultValue)
-	}
-	
-	def newConfig(seedHost:String, port: Any, timeOut:Any ): AerospikeConfig = {
-	  
-	  newConfig(Map(AerospikeConfig.SeedHost -> seedHost, 
-	      AerospikeConfig.Port -> port, 
-	      AerospikeConfig.TimeOut -> timeOut))
-	}
-	
-	
-	def newConfig(props: Map[String, Any] = null): AerospikeConfig = {
+  private def defineProperty(key: String, defaultValue: Any) : Unit = {
+    val lowerKey = key.toLowerCase()
+    if(defaultValues.contains(lowerKey))
+      sys.error(s"Config property already defined for key : $key")
+    else
+      defaultValues.put(lowerKey, defaultValue)
+  }
+
+  def newConfig(seedHost:String, port: Any, timeOut:Any ): AerospikeConfig = {
+
+    newConfig(Map(AerospikeConfig.SeedHost -> seedHost,
+      AerospikeConfig.Port -> port,
+      AerospikeConfig.TimeOut -> timeOut))
+  }
+
+
+  def newConfig(props: Map[String, Any] = null): AerospikeConfig = {
     if (props != null) {
       val ciProps = props.map(kv => kv.copy(_1 = kv._1.toLowerCase))
-      
+
       ciProps.keys.filter(_.startsWith("aerospike.")).foreach { x =>
         if(!defaultValues.contains(x))
           sys.error(s"Unknown Aerospike specific option : $x")

--- a/src/main/scala/com/aerospike/spark/sql/AerospikeConnection.scala
+++ b/src/main/scala/com/aerospike/spark/sql/AerospikeConnection.scala
@@ -24,30 +24,27 @@ object AerospikeConnection {
       newEngine
     })
   }
+
   def getClient(config: AerospikeConfig) : AerospikeClient = synchronized{
-    val host = config.get(AerospikeConfig.SeedHost);
-    val port = config.get(AerospikeConfig.Port);
-    var client = clientCache.getOrElse(s"$host:$port", {
-      newClient(config)
-    })
-    if (!client.isConnected())
+    val host = config.get(AerospikeConfig.SeedHost)
+    val port = config.get(AerospikeConfig.Port)
+    var client = clientCache.getOrElse(s"$host:$port", newClient(config))
+    if (!client.isConnected)
       client = newClient(config)
     client
   }
 
   private def newClient(config: AerospikeConfig): AerospikeClient = {
 
-    val host = config.get(AerospikeConfig.SeedHost).toString();
-    val portProperty = config.get(AerospikeConfig.Port);
-    val port = portProperty match {
-      case _:Int => portProperty.asInstanceOf[Int]
-      case _:String => portProperty.asInstanceOf[String].toInt
+    val host = config.get(AerospikeConfig.SeedHost).toString
+    val port = config.get(AerospikeConfig.Port) match {
+      case i: Int => i
+      case s: String => s.toInt
       case None => 3000
     }
-    val timeoutProperty = config.get(AerospikeConfig.TimeOut)
-    val timeOut:Int = timeoutProperty match {
-      case _:Int => timeoutProperty.asInstanceOf[Int]
-      case _:String => timeoutProperty.asInstanceOf[String].toInt
+    val timeOut:Int = config.get(AerospikeConfig.TimeOut) match {
+      case i: Int => i
+      case s: String => s.toInt
       case None => 1000
     }
     val clientPolicy = new ClientPolicy
@@ -61,11 +58,9 @@ object AerospikeConnection {
     newClient.scanPolicyDefault.timeout = timeOut
     newClient.queryPolicyDefault.timeout = timeOut
 
-    val nodes = newClient.getNodes
-    for (node <- nodes) {
-      clientCache += (node.getHost.toString() -> newClient)
+    for (node <- newClient.getNodes) {
+      clientCache += (node.getHost.toString -> newClient)
     }
     newClient
   }
-
 }

--- a/src/main/scala/com/aerospike/spark/sql/AerospikeConnection.scala
+++ b/src/main/scala/com/aerospike/spark/sql/AerospikeConnection.scala
@@ -5,67 +5,67 @@ import com.aerospike.client.AerospikeClient
 import com.aerospike.client.policy.ClientPolicy
 
 /**
- * This class caches the AerospikeClient. The key used to retrive the client is based on the
- * seen host supplied and the port.
- * 
- * The purpose of this class is to eliminate excessive client creation with
- * the goal of having 1 client per executor.
- */
+  * This class caches the AerospikeClient. The key used to retrive the client is based on the
+  * seen host supplied and the port.
+  *
+  * The purpose of this class is to eliminate excessive client creation with
+  * the goal of having 1 client per executor.
+  */
 object AerospikeConnection {
   val clientCache = new scala.collection.mutable.HashMap[String, AerospikeClient]()
   val queryEngineCache = new scala.collection.mutable.HashMap[AerospikeClient, QueryEngine]()
-  
+
   def getQueryEngine(config: AerospikeConfig) : QueryEngine = synchronized {
     val client = getClient(config: AerospikeConfig)
     queryEngineCache.getOrElse(client, {
-        val newEngine = new QueryEngine(client)
-        newEngine.refreshCluster()
-        queryEngineCache += (client -> newEngine)
-        newEngine
-      })
+      val newEngine = new QueryEngine(client)
+      newEngine.refreshCluster()
+      queryEngineCache += (client -> newEngine)
+      newEngine
+    })
   }
   def getClient(config: AerospikeConfig) : AerospikeClient = synchronized{
     val host = config.get(AerospikeConfig.SeedHost);
     val port = config.get(AerospikeConfig.Port);
     var client = clientCache.getOrElse(s"$host:$port", {
-        newClient(config)
-      })
+      newClient(config)
+    })
     if (!client.isConnected())
       client = newClient(config)
-    client   
+    client
   }
-  
+
   private def newClient(config: AerospikeConfig): AerospikeClient = {
-   
-        val host = config.get(AerospikeConfig.SeedHost).toString();
-        val portProperty = config.get(AerospikeConfig.Port);
-        val port = portProperty match {
-          case _:Int => portProperty.asInstanceOf[Int]
-          case _:String => portProperty.asInstanceOf[String].toInt
-          case None => 3000
-        }
-        val timeoutProperty = config.get(AerospikeConfig.TimeOut) 
-        val timeOut:Int = timeoutProperty match {
-          case _:Int => timeoutProperty.asInstanceOf[Int]
-          case _:String => timeoutProperty.asInstanceOf[String].toInt
-          case None => 1000
-        }
-        val clientPolicy = new ClientPolicy
-        clientPolicy.timeout = timeOut
-        clientPolicy.failIfNotConnected = true
-        val newClient = new AerospikeClient(clientPolicy, host, port)
-    
-        // set all the timeouts
-        newClient.writePolicyDefault.timeout = timeOut
-        newClient.readPolicyDefault.timeout = timeOut
-        newClient.scanPolicyDefault.timeout = timeOut
-        newClient.queryPolicyDefault.timeout = timeOut
-        
-        val nodes = newClient.getNodes
-        for (node <- nodes) {
-          clientCache += (node.getHost.toString() -> newClient)
-        }
-        newClient
+
+    val host = config.get(AerospikeConfig.SeedHost).toString();
+    val portProperty = config.get(AerospikeConfig.Port);
+    val port = portProperty match {
+      case _:Int => portProperty.asInstanceOf[Int]
+      case _:String => portProperty.asInstanceOf[String].toInt
+      case None => 3000
+    }
+    val timeoutProperty = config.get(AerospikeConfig.TimeOut)
+    val timeOut:Int = timeoutProperty match {
+      case _:Int => timeoutProperty.asInstanceOf[Int]
+      case _:String => timeoutProperty.asInstanceOf[String].toInt
+      case None => 1000
+    }
+    val clientPolicy = new ClientPolicy
+    clientPolicy.timeout = timeOut
+    clientPolicy.failIfNotConnected = true
+    val newClient = new AerospikeClient(clientPolicy, host, port)
+
+    // set all the timeouts
+    newClient.writePolicyDefault.timeout = timeOut
+    newClient.readPolicyDefault.timeout = timeOut
+    newClient.scanPolicyDefault.timeout = timeOut
+    newClient.queryPolicyDefault.timeout = timeOut
+
+    val nodes = newClient.getNodes
+    for (node <- nodes) {
+      clientCache += (node.getHost.toString() -> newClient)
+    }
+    newClient
   }
-  
+
 }

--- a/src/main/scala/com/aerospike/spark/sql/AerospikeRelation.scala
+++ b/src/main/scala/com/aerospike/spark/sql/AerospikeRelation.scala
@@ -1,7 +1,6 @@
 package com.aerospike.spark.sql
 
 import scala.collection.JavaConversions._
-import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SQLContext
@@ -13,12 +12,13 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.types.IntegerType
 import com.aerospike.client.Value
 import com.aerospike.client.query.Statement
+import com.typesafe.scalalogging.slf4j.LazyLogging
 /**
   * This class infers the schema used by the DataFrame
   * and creates an instance of @see com.aerospike.spark.sql.KeyRecordRDD
   */
 class AerospikeRelation(config: AerospikeConfig, userSchema: StructType)(@transient val sqlContext: SQLContext)
-    extends BaseRelation with TableScan with PrunedFilteredScan with Logging with Serializable {
+    extends BaseRelation with TableScan with PrunedFilteredScan with LazyLogging with Serializable {
 
   Value.UseDoubleType = true
   var schemaCache: StructType = _
@@ -44,7 +44,7 @@ class AerospikeRelation(config: AerospikeConfig, userSchema: StructType)(@transi
         sample.flatMap { keyRecord =>
           keyRecord.record.bins.map { case (binName, binVal) =>
             val field = TypeConverter.valueToSchema(binName -> binVal)
-            logDebug(s"Schema - Bin:$binName, Value:$binVal, Field:$field")
+            logger.debug(s"Schema - Bin:$binName, Value:$binVal, Field:$field")
             binName -> field
           }
         }.toMap

--- a/src/main/scala/com/aerospike/spark/sql/AerospikeRelation.scala
+++ b/src/main/scala/com/aerospike/spark/sql/AerospikeRelation.scala
@@ -1,115 +1,72 @@
 package com.aerospike.spark.sql
 
 import scala.collection.JavaConversions._
-import scala.util.parsing.json.JSONType
-
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.BinaryType
-import org.apache.spark.sql.types.DoubleType
-import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.types.MapType
-
-import com.aerospike.client.Value
-import com.aerospike.client.command.ParticleType
-import com.aerospike.helper.query.Qualifier
-import com.aerospike.helper.query.Qualifier.FilterOperation
-import com.aerospike.spark.sql.AerospikeConfig._
-import com.aerospike.helper.query.KeyRecordIterator
-import com.aerospike.client.query.KeyRecord
-import com.aerospike.client.query.Statement
-import com.aerospike.client.policy.QueryPolicy
-import com.aerospike.client.AerospikeClient
-import scala.collection.mutable.ListBuffer
 import org.apache.spark.sql.types.IntegerType
-import scala.collection.immutable.ListMap
-
+import com.aerospike.client.Value
+import com.aerospike.client.query.Statement
 /**
   * This class infers the schema used by the DataFrame
   * and creates an instance of @see com.aerospike.spark.sql.KeyRecordRDD
   */
-class AerospikeRelation( config: AerospikeConfig, userSchema: StructType)
-  (@transient val sqlContext: SQLContext)
-    extends BaseRelation
-    with TableScan
-    with PrunedFilteredScan
-    with Logging
-    with Serializable {
+class AerospikeRelation(config: AerospikeConfig, userSchema: StructType)(@transient val sqlContext: SQLContext)
+    extends BaseRelation with TableScan with PrunedFilteredScan with Logging with Serializable {
 
   Value.UseDoubleType = true
-
-  val conf = config
-
-  var schemaCache: StructType = null
+  var schemaCache: StructType = _
 
   override def schema: StructType = {
-    val SCAN_COUNT = config.schemaScan()
-
     if (schemaCache == null || schemaCache.isEmpty) {
-
       val client = AerospikeConnection.getClient(config)
+      val fields = Vector[StructField](
+        StructField(config.keyColumn(), StringType, nullable = true),
+        StructField(config.digestColumn(), BinaryType, nullable = false),
+        StructField(config.expiryColumn(), IntegerType, nullable = false),
+        StructField(config.generationColumn(), IntegerType, nullable = false),
+        StructField(config.ttlColumn(), IntegerType, nullable = false)
+      )
 
-      var bins = collection.mutable.Map[String,StructField]()
-      var fields = ListBuffer[StructField]()
-      fields += StructField(config.keyColumn(), StringType, true)
-      fields += StructField(config.digestColumn(), BinaryType, false)
-      fields += StructField(config.expiryColumn(), IntegerType, false)
-      fields += StructField(config.generationColumn(), IntegerType, false)
-      fields += StructField(config.ttlColumn(), IntegerType, false)
+      val stmt = new Statement()
+      stmt.setNamespace(config.get(AerospikeConfig.NameSpace).asInstanceOf[String])
+      stmt.setSetName(config.get(AerospikeConfig.SetName).asInstanceOf[String])
 
-      var stmt = new Statement();
-      stmt.setNamespace(config.get(AerospikeConfig.NameSpace).asInstanceOf[String]);
-      stmt.setSetName(config.get(AerospikeConfig.SetName).asInstanceOf[String]);
-      var recordSet = client.query(null, stmt)
-
-      try{
-        val sample = recordSet.take(SCAN_COUNT)
-        sample.foreach { keyRecord =>
-
-          keyRecord.record.bins.foreach { bin =>
-            val binVal = bin._2
-            val binName = bin._1
-            val field = TypeConverter.valueToSchema(bin)
+      val recordSet = client.query(null, stmt)
+      val bins: Map[String, StructField] = try {
+        val sample = recordSet.take(config.schemaScan())
+        sample.flatMap { keyRecord =>
+          keyRecord.record.bins.map { case (binName, binVal) =>
+            val field = TypeConverter.valueToSchema(binName -> binVal)
             logDebug(s"Schema - Bin:$binName, Value:$binVal, Field:$field")
-            bins.get(binName) match {
-              case Some(e) => bins.update(binName, field)
-              case None    => bins += binName -> field
-            }
+            binName -> field
           }
-        }
-
+        }.toMap
+      } catch {
+        case e: Exception => Map.empty[String, StructField]
       } finally {
-        recordSet.close();
+        recordSet.close()
       }
-      // sort fields by bin name
-      bins.toSeq.sortBy(_._1).map(bin => fields += bin._2)
-
-      val fieldSeq = fields.toSeq
-      schemaCache = StructType(fieldSeq)
+      schemaCache = StructType(fields ++ bins.values)
     }
     schemaCache
   }
 
   override def buildScan(): RDD[Row] = {
-    new KeyRecordRDD(sqlContext.sparkContext, conf, schemaCache)
+    new KeyRecordRDD(sqlContext.sparkContext, config, schemaCache)
   }
 
-
-  override def buildScan(
-    requiredColumns: Array[String],
-    filters: Array[Filter]): RDD[Row] = {
-    if (filters.length >0){
-      new KeyRecordRDD(sqlContext.sparkContext, conf, schemaCache, requiredColumns, filters)
+  override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
+    if (filters.length > 0) {
+      new KeyRecordRDD(sqlContext.sparkContext, config, schemaCache, requiredColumns, filters)
     } else {
-      new KeyRecordRDD(sqlContext.sparkContext, conf, schemaCache, requiredColumns)
+      new KeyRecordRDD(sqlContext.sparkContext, config, schemaCache, requiredColumns)
     }
   }
-
-
 }

--- a/src/main/scala/com/aerospike/spark/sql/AerospikeRelation.scala
+++ b/src/main/scala/com/aerospike/spark/sql/AerospikeRelation.scala
@@ -31,76 +31,76 @@ import org.apache.spark.sql.types.IntegerType
 import scala.collection.immutable.ListMap
 
 /**
- * This class infers the schema used by the DataFrame
- * and creates an instance of @see com.aerospike.spark.sql.KeyRecordRDD
- */
+  * This class infers the schema used by the DataFrame
+  * and creates an instance of @see com.aerospike.spark.sql.KeyRecordRDD
+  */
 class AerospikeRelation( config: AerospikeConfig, userSchema: StructType)
-  (@transient val sqlContext: SQLContext) 
+  (@transient val sqlContext: SQLContext)
     extends BaseRelation
     with TableScan
-    with PrunedFilteredScan 
-    with Logging 
+    with PrunedFilteredScan
+    with Logging
     with Serializable {
-  
+
   Value.UseDoubleType = true
 
   val conf = config
-  
+
   var schemaCache: StructType = null
 
   override def schema: StructType = {
     val SCAN_COUNT = config.schemaScan()
-    
+
     if (schemaCache == null || schemaCache.isEmpty) {
 
-      val client = AerospikeConnection.getClient(config) 
-      
+      val client = AerospikeConnection.getClient(config)
+
       var bins = collection.mutable.Map[String,StructField]()
       var fields = ListBuffer[StructField]()
-  		fields += StructField(config.keyColumn(), StringType, true)
-  		fields += StructField(config.digestColumn(), BinaryType, false)
-  		fields += StructField(config.expiryColumn(), IntegerType, false)
-  		fields += StructField(config.generationColumn(), IntegerType, false)
-  		fields += StructField(config.ttlColumn(), IntegerType, false)
-     
-  		var stmt = new Statement();
-  		stmt.setNamespace(config.get(AerospikeConfig.NameSpace).asInstanceOf[String]);
-  		stmt.setSetName(config.get(AerospikeConfig.SetName).asInstanceOf[String]);
-  		var recordSet = client.query(null, stmt)
-  		    
-  		try{
-  		  val sample = recordSet.take(SCAN_COUNT)
-  			sample.foreach { keyRecord => 
-    
+      fields += StructField(config.keyColumn(), StringType, true)
+      fields += StructField(config.digestColumn(), BinaryType, false)
+      fields += StructField(config.expiryColumn(), IntegerType, false)
+      fields += StructField(config.generationColumn(), IntegerType, false)
+      fields += StructField(config.ttlColumn(), IntegerType, false)
+
+      var stmt = new Statement();
+      stmt.setNamespace(config.get(AerospikeConfig.NameSpace).asInstanceOf[String]);
+      stmt.setSetName(config.get(AerospikeConfig.SetName).asInstanceOf[String]);
+      var recordSet = client.query(null, stmt)
+
+      try{
+        val sample = recordSet.take(SCAN_COUNT)
+        sample.foreach { keyRecord =>
+
           keyRecord.record.bins.foreach { bin =>
             val binVal = bin._2
             val binName = bin._1
             val field = TypeConverter.valueToSchema(bin)
-           logDebug(s"Schema - Bin:$binName, Value:$binVal, Field:$field")
-              bins.get(binName) match {
-                case Some(e) => bins.update(binName, field)
-                case None    => bins += binName -> field
-              }
+            logDebug(s"Schema - Bin:$binName, Value:$binVal, Field:$field")
+            bins.get(binName) match {
+              case Some(e) => bins.update(binName, field)
+              case None    => bins += binName -> field
             }
-  			}
-  
-  		} finally {
-  			recordSet.close();
-  		}
-  		// sort fields by bin name
-  		bins.toSeq.sortBy(_._1).map(bin => fields += bin._2)
-  		
-  		val fieldSeq = fields.toSeq
-  		schemaCache = StructType(fieldSeq)
-  	} 
+          }
+        }
+
+      } finally {
+        recordSet.close();
+      }
+      // sort fields by bin name
+      bins.toSeq.sortBy(_._1).map(bin => fields += bin._2)
+
+      val fieldSeq = fields.toSeq
+      schemaCache = StructType(fieldSeq)
+    }
     schemaCache
   }
-  
+
   override def buildScan(): RDD[Row] = {
     new KeyRecordRDD(sqlContext.sparkContext, conf, schemaCache)
   }
-  
-  
+
+
   override def buildScan(
     requiredColumns: Array[String],
     filters: Array[Filter]): RDD[Row] = {
@@ -110,6 +110,6 @@ class AerospikeRelation( config: AerospikeConfig, userSchema: StructType)
       new KeyRecordRDD(sqlContext.sparkContext, conf, schemaCache, requiredColumns)
     }
   }
-  
-  
+
+
 }

--- a/src/main/scala/com/aerospike/spark/sql/DefaultSource.scala
+++ b/src/main/scala/com/aerospike/spark/sql/DefaultSource.scala
@@ -24,161 +24,161 @@ import com.aerospike.client.policy.GenerationPolicy
 
 
 /**
- * This class provides implementations to the Spark load and save functions
- */
+  * This class provides implementations to the Spark load and save functions
+  */
 class DefaultSource extends RelationProvider with Serializable
-with Logging
-with CreatableRelationProvider{
-  
-	override def createRelation(sqlContext: SQLContext, 
-			parameters: Map[String, String]): BaseRelation = {
-					parameters.getOrElse(AerospikeConfig.SeedHost, sys.error(AerospikeConfig.SeedHost + " must be specified"))
-					parameters.getOrElse(AerospikeConfig.Port, sys.error(AerospikeConfig.Port + " must be specified"))
-					parameters.getOrElse(AerospikeConfig.NameSpace, sys.error(AerospikeConfig.NameSpace + " must be specified"))
-					logInfo("Creating Aerospike relation for " + AerospikeConfig.NameSpace +":"+ AerospikeConfig.SetName)
-					val conf = AerospikeConfig.newConfig(parameters)
-					val ref = new AerospikeRelation(conf, null)(sqlContext)
-					return ref
-	}
+    with Logging
+    with CreatableRelationProvider{
 
-	override def createRelation(
-			sqlContext: SQLContext,
-			mode: SaveMode,
-			parameters: Map[String, String],
-			data: DataFrame): BaseRelation = {
+  override def createRelation(sqlContext: SQLContext,
+    parameters: Map[String, String]): BaseRelation = {
+    parameters.getOrElse(AerospikeConfig.SeedHost, sys.error(AerospikeConfig.SeedHost + " must be specified"))
+    parameters.getOrElse(AerospikeConfig.Port, sys.error(AerospikeConfig.Port + " must be specified"))
+    parameters.getOrElse(AerospikeConfig.NameSpace, sys.error(AerospikeConfig.NameSpace + " must be specified"))
+    logInfo("Creating Aerospike relation for " + AerospikeConfig.NameSpace +":"+ AerospikeConfig.SetName)
+    val conf = AerospikeConfig.newConfig(parameters)
+    val ref = new AerospikeRelation(conf, null)(sqlContext)
+    return ref
+  }
 
-			val conf = AerospikeConfig.newConfig(parameters)
+  override def createRelation(
+    sqlContext: SQLContext,
+    mode: SaveMode,
+    parameters: Map[String, String],
+    data: DataFrame): BaseRelation = {
 
-			saveDataFrame(data, mode, conf)
+    val conf = AerospikeConfig.newConfig(parameters)
 
-			createRelation(sqlContext, parameters)
-	}
+    saveDataFrame(data, mode, conf)
 
-	def saveDataFrame(data: DataFrame, mode: SaveMode, config: AerospikeConfig){
-		val schema = data.schema
-				data.foreachPartition { iterator =>
-				savePartition(iterator, schema, mode, config) }
-	}
+    createRelation(sqlContext, parameters)
+  }
 
-	private def savePartition(iterator: Iterator[Row],
-			schema: StructType, mode: SaveMode, config: AerospikeConfig): Unit = { 
-	  
-	  val metaFields = Set(config.keyColumn(),
-        config.digestColumn(), 
-        config.expiryColumn(), 
-        config.generationColumn(), 
-        config.ttlColumn())
-    
+  def saveDataFrame(data: DataFrame, mode: SaveMode, config: AerospikeConfig){
+    val schema = data.schema
+    data.foreachPartition { iterator =>
+      savePartition(iterator, schema, mode, config) }
+  }
+
+  private def savePartition(iterator: Iterator[Row],
+    schema: StructType, mode: SaveMode, config: AerospikeConfig): Unit = {
+
+    val metaFields = Set(config.keyColumn(),
+      config.digestColumn(),
+      config.expiryColumn(),
+      config.generationColumn(),
+      config.ttlColumn())
+
     val fieldNames = schema.fields.map { field => field.name}.toSet
     val binsOnly = fieldNames.toSet.diff(metaFields).toSeq.sortWith(_ < _)
 
-	  val hasUpdateByKey = config.get(AerospikeConfig.UpdateByKey) != null
-		val hasUpdateByDigest = config.get(AerospikeConfig.UpdateByDigest) != null
+    val hasUpdateByKey = config.get(AerospikeConfig.UpdateByKey) != null
+    val hasUpdateByDigest = config.get(AerospikeConfig.UpdateByDigest) != null
 
     if(hasUpdateByDigest && hasUpdateByKey){
       sys.error("Cannot use hasUpdateByKey and hasUpdateByDigest configuration together")
     }
-	  
-		logDebug("fetch client to save partition")
-		val client = AerospikeConnection.getClient(config)
 
-		logDebug("creating write policy")
-		
-		val policy = new WritePolicy(client.writePolicyDefault)
-		
-		mode match {
-			case SaveMode.ErrorIfExists => policy.recordExistsAction = RecordExistsAction.CREATE_ONLY
-			case SaveMode.Ignore => policy.recordExistsAction = RecordExistsAction.CREATE_ONLY
-			case SaveMode.Overwrite => policy.recordExistsAction = RecordExistsAction.REPLACE
-			case SaveMode.Append => policy.recordExistsAction = RecordExistsAction.UPDATE_ONLY
-		}
+    logDebug("fetch client to save partition")
+    val client = AerospikeConnection.getClient(config)
 
-		val genPol = config.get(AerospikeConfig.generationPolicy)
-		
-		if (genPol != null) {
-		  policy.generationPolicy = genPol.asInstanceOf[GenerationPolicy]
-		}
-		
-		var counter = 0
-		
-		while (iterator.hasNext) {
-			val row = iterator.next()
-			
-			var key: Key = null
-			
-			if (hasUpdateByDigest) {
-			  val digestColumn = config.get(AerospikeConfig.UpdateByDigest).toString()
-			  val digest = row(schema.fieldIndex(digestColumn)).asInstanceOf[Array[Byte]]
-			  key = new Key(config.namespace(), digest, null, null)
-			} else {
-			  val keyColumn = config.get(AerospikeConfig.UpdateByKey).toString()
-			  val keyObject: Object = row(schema.fieldIndex(keyColumn)).asInstanceOf[Object]
-			  key = new Key(config.namespace(), config.set(), Value.get(keyObject))
-			}
-			
-			var bins = ListBuffer[Bin]()
-			binsOnly.foreach { binName => 
-			  val bin = TypeConverter.fieldToBin(schema, row, binName)
-			  bins += bin
-			}
-			try {
-			  
-			  if (policy.generationPolicy == GenerationPolicy.EXPECT_GEN_EQUAL){
-			    policy.generation = row(schema.fieldIndex(config.generationColumn)).asInstanceOf[java.lang.Integer].intValue
-			  }
-			  
-			  if (schema.fieldNames.contains(config.ttlColumn)){
-			    var  expIndex = schema.fieldIndex(config.ttlColumn)
-			    policy.expiration = row(expIndex).asInstanceOf[java.lang.Integer].intValue
-			  }
-			  val binArray = bins.toArray
-			  client.put(policy, key, binArray:_*)
-				
-			  counter += 1;  
-			} catch {
-        case ex: AerospikeException => {
-        		val message = ex.getMessage
-            mode match {
-        			case SaveMode.ErrorIfExists => {
-        			  ex.getResultCode match {
-        			    case ResultCode.KEY_EXISTS_ERROR =>
-        			      logDebug(s"Key:$key Error:$message")
-        			      throw ex
-        			    case _ =>
-        			      logError(s"Key:$key Error:$message")
-        			  }
-        			}
-        			
-        			case SaveMode.Ignore => {
-        			  ex.getResultCode match {
-        			    case ResultCode.KEY_EXISTS_ERROR =>
-        			      logDebug(s"Ignoring existing Key:$key")
-        			    case _ => 
-        			      logError(s"Key:$key Error:$message")
-        			      throw ex
-        			  }
-        			}
-        			
-        			case SaveMode.Overwrite => {
-        			  logError(s"Key:$key Error:$message")
-        			  //throw ex
-        			}
-        			
-        			case SaveMode.Append => {
-        			  ex.getResultCode match {
-        			    case ResultCode.KEY_NOT_FOUND_ERROR =>
-        			      logDebug(s"Ignoring missing Key:$key")
-        			    case _ =>
-        			      logError(s"Key:$key Error:$message")
-        			      throw ex
-        			  }
-        			}
-        		}   
+    logDebug("creating write policy")
+
+    val policy = new WritePolicy(client.writePolicyDefault)
+
+    mode match {
+      case SaveMode.ErrorIfExists => policy.recordExistsAction = RecordExistsAction.CREATE_ONLY
+      case SaveMode.Ignore => policy.recordExistsAction = RecordExistsAction.CREATE_ONLY
+      case SaveMode.Overwrite => policy.recordExistsAction = RecordExistsAction.REPLACE
+      case SaveMode.Append => policy.recordExistsAction = RecordExistsAction.UPDATE_ONLY
+    }
+
+    val genPol = config.get(AerospikeConfig.generationPolicy)
+
+    if (genPol != null) {
+      policy.generationPolicy = genPol.asInstanceOf[GenerationPolicy]
+    }
+
+    var counter = 0
+
+    while (iterator.hasNext) {
+      val row = iterator.next()
+
+      var key: Key = null
+
+      if (hasUpdateByDigest) {
+        val digestColumn = config.get(AerospikeConfig.UpdateByDigest).toString()
+        val digest = row(schema.fieldIndex(digestColumn)).asInstanceOf[Array[Byte]]
+        key = new Key(config.namespace(), digest, null, null)
+      } else {
+        val keyColumn = config.get(AerospikeConfig.UpdateByKey).toString()
+        val keyObject: Object = row(schema.fieldIndex(keyColumn)).asInstanceOf[Object]
+        key = new Key(config.namespace(), config.set(), Value.get(keyObject))
+      }
+
+      var bins = ListBuffer[Bin]()
+      binsOnly.foreach { binName =>
+        val bin = TypeConverter.fieldToBin(schema, row, binName)
+        bins += bin
+      }
+      try {
+
+        if (policy.generationPolicy == GenerationPolicy.EXPECT_GEN_EQUAL){
+          policy.generation = row(schema.fieldIndex(config.generationColumn)).asInstanceOf[java.lang.Integer].intValue
         }
-      } 
-		}
-		logDebug(s"Completed writing partition of $counter rows")
 
-	}
-	
+        if (schema.fieldNames.contains(config.ttlColumn)){
+          var  expIndex = schema.fieldIndex(config.ttlColumn)
+          policy.expiration = row(expIndex).asInstanceOf[java.lang.Integer].intValue
+        }
+        val binArray = bins.toArray
+        client.put(policy, key, binArray:_*)
+
+        counter += 1;
+      } catch {
+        case ex: AerospikeException => {
+          val message = ex.getMessage
+          mode match {
+            case SaveMode.ErrorIfExists => {
+              ex.getResultCode match {
+                case ResultCode.KEY_EXISTS_ERROR =>
+                  logDebug(s"Key:$key Error:$message")
+                  throw ex
+                case _ =>
+                  logError(s"Key:$key Error:$message")
+              }
+            }
+
+            case SaveMode.Ignore => {
+              ex.getResultCode match {
+                case ResultCode.KEY_EXISTS_ERROR =>
+                  logDebug(s"Ignoring existing Key:$key")
+                case _ =>
+                  logError(s"Key:$key Error:$message")
+                  throw ex
+              }
+            }
+
+            case SaveMode.Overwrite => {
+              logError(s"Key:$key Error:$message")
+              //throw ex
+            }
+
+            case SaveMode.Append => {
+              ex.getResultCode match {
+                case ResultCode.KEY_NOT_FOUND_ERROR =>
+                  logDebug(s"Ignoring missing Key:$key")
+                case _ =>
+                  logError(s"Key:$key Error:$message")
+                  throw ex
+              }
+            }
+          }
+        }
+      }
+    }
+    logDebug(s"Completed writing partition of $counter rows")
+
+  }
+
 }

--- a/src/main/scala/com/aerospike/spark/sql/KeyRecordRDD.scala
+++ b/src/main/scala/com/aerospike/spark/sql/KeyRecordRDD.scala
@@ -28,41 +28,41 @@ import org.apache.spark.sql.types.MapType
 
 
 case class AerospikePartition(index: Int,
-                              host: String) extends Partition()
+  host: String) extends Partition()
 
 /**
- * This is an Aerospike specific RDD to contains the results 
- * of a Scan or Query operation.
- * 
- * NOTE: This class uses the @see com.aerospike.helper.query.QueryEngine to 
- * provide multiple filters in the Aerospike server.
- * 
- */
+  * This is an Aerospike specific RDD to contains the results
+  * of a Scan or Query operation.
+  *
+  * NOTE: This class uses the @see com.aerospike.helper.query.QueryEngine to
+  * provide multiple filters in the Aerospike server.
+  *
+  */
 class KeyRecordRDD(
-                    @transient val sc: SparkContext,
-                    val aerospikeConfig: AerospikeConfig,
-                    val schema: StructType = null,
-                    val requiredColumns: Array[String] = null,
-                    val filters: Array[Filter] = null
-                    ) extends RDD[Row](sc, Seq.empty) with Logging {  
-  
+  @transient val sc: SparkContext,
+  val aerospikeConfig: AerospikeConfig,
+  val schema: StructType = null,
+  val requiredColumns: Array[String] = null,
+  val filters: Array[Filter] = null
+) extends RDD[Row](sc, Seq.empty) with Logging {
+
 
   override protected def getPartitions: Array[Partition] = {
     {
-      var client = AerospikeConnection.getClient(aerospikeConfig) 
+      var client = AerospikeConnection.getClient(aerospikeConfig)
       var nodes = client.getNodes
       var count = 0
       var parts = new Array[Partition](nodes.size)
-      nodes.foreach { node => 
+      nodes.foreach { node =>
         val name = node.getName
-        parts(count) = new AerospikePartition(count, name).asInstanceOf[Partition] 
+        parts(count) = new AerospikePartition(count, name).asInstanceOf[Partition]
         count += 1
-        }
+      }
       parts
     }.toArray
   }
-  
-  
+
+
   override def compute(split: Partition, context: TaskContext): Iterator[Row] = {
     val partition: AerospikePartition = split.asInstanceOf[AerospikePartition]
     val partHost = partition.host
@@ -76,15 +76,15 @@ class KeyRecordRDD(
     if (requiredColumns != null && requiredColumns.length > 0){
       val binsOnly = TypeConverter.binNamesOnly(requiredColumns, metaFields)
       logDebug(s"Bin names: $binsOnly")
-      stmt.setBinNames(binsOnly: _*) 
+      stmt.setBinNames(binsOnly: _*)
     }
-    
+
     val queryEngine = AerospikeConnection.getQueryEngine(aerospikeConfig)
     val client = AerospikeConnection.getClient(aerospikeConfig)
     val node = client.getNode(partition.host);
-    
+
     var kri: KeyRecordIterator = null
-    
+
     if (filters != null && filters.length > 0){
       val qualifiers = filters.map { phil => filterToQualifier(phil) }
       kri = queryEngine.select(stmt, false, node, qualifiers: _*)
@@ -92,104 +92,103 @@ class KeyRecordRDD(
       kri = queryEngine.select(stmt, false, node)
     }
 
-    context.addTaskCompletionListener(context => { 
+    context.addTaskCompletionListener(context => {
       logInfo(s"KeyRecordIterator closed for Aerospike host $partHost")
-      kri.close() 
-      })
-    
-    
+      kri.close()
+    })
+
+
     new RowIterator(kri, schema, aerospikeConfig, requiredColumns)
   }
-  
-  private def filterToQualifier(filter: Filter) = filter match {   
-      case EqualTo(attribute, value) =>
-        if (isList(attribute)){
-          new Qualifier(attribute, FilterOperation.LIST_CONTAINS, Value.get(value))  // TODO experimental
-        } else if (isMap(attribute)){
-          new Qualifier(attribute, FilterOperation.MAP_KEYS_CONTAINS, Value.get(value)) //TODO experimental
-        } else {
-          new Qualifier(attribute, FilterOperation.EQ, Value.get(value))
-        }
-      case GreaterThanOrEqual(attribute, value) =>
-        new Qualifier(attribute, FilterOperation.GTEQ, Value.get(value))
 
-      case GreaterThan(attribute, value) =>
-        new Qualifier(attribute, FilterOperation.GT, Value.get(value))
+  private def filterToQualifier(filter: Filter) = filter match {
+    case EqualTo(attribute, value) =>
+      if (isList(attribute)){
+        new Qualifier(attribute, FilterOperation.LIST_CONTAINS, Value.get(value))  // TODO experimental
+      } else if (isMap(attribute)){
+        new Qualifier(attribute, FilterOperation.MAP_KEYS_CONTAINS, Value.get(value)) //TODO experimental
+      } else {
+        new Qualifier(attribute, FilterOperation.EQ, Value.get(value))
+      }
+    case GreaterThanOrEqual(attribute, value) =>
+      new Qualifier(attribute, FilterOperation.GTEQ, Value.get(value))
 
-      case LessThanOrEqual(attribute, value) =>
-        new Qualifier(attribute, FilterOperation.LTEQ, Value.get(value))
+    case GreaterThan(attribute, value) =>
+      new Qualifier(attribute, FilterOperation.GT, Value.get(value))
 
-      case LessThan(attribute, value) =>
-        new Qualifier(attribute, FilterOperation.LT, Value.get(value))
+    case LessThanOrEqual(attribute, value) =>
+      new Qualifier(attribute, FilterOperation.LTEQ, Value.get(value))
 
-      case StringStartsWith(attribute, value) =>
-          new Qualifier(attribute, FilterOperation.START_WITH, Value.get(value))
-          
-      case StringEndsWith(attribute, value) =>
-          new Qualifier(attribute, FilterOperation.ENDS_WITH, Value.get(value))
-          
-      case _ => null            
-  }    
+    case LessThan(attribute, value) =>
+      new Qualifier(attribute, FilterOperation.LT, Value.get(value))
+
+    case StringStartsWith(attribute, value) =>
+      new Qualifier(attribute, FilterOperation.START_WITH, Value.get(value))
+
+    case StringEndsWith(attribute, value) =>
+      new Qualifier(attribute, FilterOperation.ENDS_WITH, Value.get(value))
+
+    case _ => null
+  }
 
   private def isMap(attribute: String) = {
-    schema(attribute).dataType match {   
+    schema(attribute).dataType match {
       case _: MapType => true
       case _ => false
     }
   }
   private def isList(attribute: String) = {
-    schema(attribute).dataType match {   
+    schema(attribute).dataType match {
       case _: ArrayType => true
       case _ => false
     }
   }
 }
 /**
- * This class implement a Spark SQL row iterator.
- * It is used to iterate through the Record/Result set from the Aerospike query
- */
+  * This class implement a Spark SQL row iterator.
+  * It is used to iterate through the Record/Result set from the Aerospike query
+  */
 class RowIterator[Row] (val kri: KeyRecordIterator, schema: StructType, aerospikeConfig: AerospikeConfig, requiredColumns: Array[String] = null) extends Iterator[org.apache.spark.sql.Row] with Logging{
-      
-      
-      def hasNext: Boolean = {
-        kri.hasNext()
-      }
-     
-      def next: org.apache.spark.sql.Row = {
-         val kr = kri.next()
-         
-         val digest: Array[Byte] = kr.key.digest
-         val digestName: String = aerospikeConfig.digestColumn()
-         
-         val userKey: Value = kr.key.userKey
-         val userKeyName: String = aerospikeConfig.keyColumn()
-         
-         val expiration: Int = kr.record.expiration
-         val expirationName: String = aerospikeConfig.expiryColumn()
-         
-         val generation: Int = kr.record.generation
-         val generationName: String = aerospikeConfig.generationColumn()
-         
-         val ttl: Int = kr.record.getTimeToLive
-         val ttlName: String = aerospikeConfig.ttlColumn()
-         
-         var fields = scala.collection.mutable.MutableList[Any]()
-         
-         requiredColumns.foreach { field => 
-            val value = field match {
-              case x if x.equals(digestName) => digest
-              case x if x.equals(userKeyName) => if (userKey != null) userKey else null
-              case x if x.equals(expirationName) => expiration
-              case x if x.equals(generationName) => generation
-              case x if x.equals(ttlName) => ttl
-              case _ => TypeConverter.binToValue(schema, (field, kr.record.bins.get(field)))
-            }
-            logDebug(s"$field = $value")
-            fields += value
-         }
-        
-        val row = Row.fromSeq(fields.toSeq)
-        row
-      }
-}
 
+
+  def hasNext: Boolean = {
+    kri.hasNext()
+  }
+
+  def next: org.apache.spark.sql.Row = {
+    val kr = kri.next()
+
+    val digest: Array[Byte] = kr.key.digest
+    val digestName: String = aerospikeConfig.digestColumn()
+
+    val userKey: Value = kr.key.userKey
+    val userKeyName: String = aerospikeConfig.keyColumn()
+
+    val expiration: Int = kr.record.expiration
+    val expirationName: String = aerospikeConfig.expiryColumn()
+
+    val generation: Int = kr.record.generation
+    val generationName: String = aerospikeConfig.generationColumn()
+
+    val ttl: Int = kr.record.getTimeToLive
+    val ttlName: String = aerospikeConfig.ttlColumn()
+
+    var fields = scala.collection.mutable.MutableList[Any]()
+
+    requiredColumns.foreach { field =>
+      val value = field match {
+        case x if x.equals(digestName) => digest
+        case x if x.equals(userKeyName) => if (userKey != null) userKey else null
+        case x if x.equals(expirationName) => expiration
+        case x if x.equals(generationName) => generation
+        case x if x.equals(ttlName) => ttl
+        case _ => TypeConverter.binToValue(schema, (field, kr.record.bins.get(field)))
+      }
+      logDebug(s"$field = $value")
+      fields += value
+    }
+
+    val row = Row.fromSeq(fields.toSeq)
+    row
+  }
+}

--- a/src/main/scala/com/aerospike/spark/sql/KeyRecordRDD.scala
+++ b/src/main/scala/com/aerospike/spark/sql/KeyRecordRDD.scala
@@ -1,11 +1,8 @@
 package com.aerospike.spark.sql
 
-import scala.collection.JavaConversions._
-
 import org.apache.spark._
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources.EqualTo
 import org.apache.spark.sql.sources.Filter
@@ -19,7 +16,6 @@ import org.apache.spark.sql.sources.StringEndsWith
 import org.apache.spark.sql.types.StructType
 
 import com.aerospike.client.Value
-import com.aerospike.client.cluster.Node
 import com.aerospike.client.query.Statement
 import com.aerospike.helper.query._
 import com.aerospike.helper.query.Qualifier.FilterOperation
@@ -27,8 +23,7 @@ import org.apache.spark.sql.types.ArrayType
 import org.apache.spark.sql.types.MapType
 
 
-case class AerospikePartition(index: Int,
-  host: String) extends Partition()
+case class AerospikePartition(index: Int, host: String) extends Partition
 
 /**
   * This is an Aerospike specific RDD to contains the results
@@ -48,20 +43,17 @@ class KeyRecordRDD(
 
 
   override protected def getPartitions: Array[Partition] = {
-    {
-      var client = AerospikeConnection.getClient(aerospikeConfig)
-      var nodes = client.getNodes
-      var count = 0
-      var parts = new Array[Partition](nodes.size)
-      nodes.foreach { node =>
-        val name = node.getName
-        parts(count) = new AerospikePartition(count, name).asInstanceOf[Partition]
-        count += 1
-      }
-      parts
-    }.toArray
+    val client = AerospikeConnection.getClient(aerospikeConfig)
+    val nodes = client.getNodes
+    var count = 0
+    val parts = new Array[Partition](nodes.size)
+    nodes.foreach { node =>
+      val name = node.getName
+      parts(count) = AerospikePartition(count, name).asInstanceOf[Partition]
+      count += 1
+    }
+    parts
   }
-
 
   override def compute(split: Partition, context: TaskContext): Iterator[Row] = {
     val partition: AerospikePartition = split.asInstanceOf[AerospikePartition]
@@ -81,23 +73,19 @@ class KeyRecordRDD(
 
     val queryEngine = AerospikeConnection.getQueryEngine(aerospikeConfig)
     val client = AerospikeConnection.getClient(aerospikeConfig)
-    val node = client.getNode(partition.host);
+    val node = client.getNode(partition.host)
 
-    var kri: KeyRecordIterator = null
-
-    if (filters != null && filters.length > 0){
+    val kri = if (filters != null && filters.length > 0){
       val qualifiers = filters.map { phil => filterToQualifier(phil) }
-      kri = queryEngine.select(stmt, false, node, qualifiers: _*)
+      queryEngine.select(stmt, false, node, qualifiers: _*)
     } else {
-      kri = queryEngine.select(stmt, false, node)
+      queryEngine.select(stmt, false, node)
     }
 
     context.addTaskCompletionListener(context => {
       logInfo(s"KeyRecordIterator closed for Aerospike host $partHost")
       kri.close()
     })
-
-
     new RowIterator(kri, schema, aerospikeConfig, requiredColumns)
   }
 
@@ -148,47 +136,44 @@ class KeyRecordRDD(
   * This class implement a Spark SQL row iterator.
   * It is used to iterate through the Record/Result set from the Aerospike query
   */
-class RowIterator[Row] (val kri: KeyRecordIterator, schema: StructType, aerospikeConfig: AerospikeConfig, requiredColumns: Array[String] = null) extends Iterator[org.apache.spark.sql.Row] with Logging{
+class RowIterator[Row] (val kri: KeyRecordIterator, schema: StructType, config: AerospikeConfig, requiredColumns: Array[String] = null)
+  extends Iterator[org.apache.spark.sql.Row] with Logging {
 
 
   def hasNext: Boolean = {
-    kri.hasNext()
+    kri.hasNext
   }
 
   def next: org.apache.spark.sql.Row = {
     val kr = kri.next()
 
     val digest: Array[Byte] = kr.key.digest
-    val digestName: String = aerospikeConfig.digestColumn()
+    val digestName: String = config.digestColumn()
 
     val userKey: Value = kr.key.userKey
-    val userKeyName: String = aerospikeConfig.keyColumn()
+    val userKeyName: String = config.keyColumn()
 
     val expiration: Int = kr.record.expiration
-    val expirationName: String = aerospikeConfig.expiryColumn()
+    val expirationName: String = config.expiryColumn()
 
     val generation: Int = kr.record.generation
-    val generationName: String = aerospikeConfig.generationColumn()
+    val generationName: String = config.generationColumn()
 
     val ttl: Int = kr.record.getTimeToLive
-    val ttlName: String = aerospikeConfig.ttlColumn()
+    val ttlName: String = config.ttlColumn()
 
-    var fields = scala.collection.mutable.MutableList[Any]()
-
-    requiredColumns.foreach { field =>
+    val fields = requiredColumns.map { field =>
       val value = field match {
         case x if x.equals(digestName) => digest
-        case x if x.equals(userKeyName) => if (userKey != null) userKey else null
+        case x if x.equals(userKeyName) => userKey
         case x if x.equals(expirationName) => expiration
         case x if x.equals(generationName) => generation
         case x if x.equals(ttlName) => ttl
         case _ => TypeConverter.binToValue(schema, (field, kr.record.bins.get(field)))
       }
       logDebug(s"$field = $value")
-      fields += value
+      value
     }
-
-    val row = Row.fromSeq(fields.toSeq)
-    row
+    Row.fromSeq(fields)
   }
 }

--- a/src/main/scala/com/aerospike/spark/sql/TypeConverter.scala
+++ b/src/main/scala/com/aerospike/spark/sql/TypeConverter.scala
@@ -1,25 +1,11 @@
 package com.aerospike.spark.sql
 
-import scala.collection.mutable.WrappedArray
-
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.ArrayType
-import org.apache.spark.sql.types.BinaryType
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.types.DateType
-import org.apache.spark.sql.types.DoubleType
-import org.apache.spark.sql.types.FloatType
-import org.apache.spark.sql.types.IntegerType
-import org.apache.spark.sql.types.LongType
-import org.apache.spark.sql.types.MapType
-import org.apache.spark.sql.types.NullType
-import org.apache.spark.sql.types.ShortType
-import org.apache.spark.sql.types.StringType
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types._
 import collection.JavaConverters._
-
 import com.aerospike.client.Bin
+
+import scala.collection.mutable
 
 
 /**
@@ -28,13 +14,13 @@ import com.aerospike.client.Bin
   */
 object TypeConverter{
 
-  def binNamesOnly(fieldNames:Array[String], metaFields:Set[String]):Array[String] = {
-    val binsOnly = fieldNames.toSet.diff(metaFields).toSeq.sortWith(_ < _)
-    binsOnly.toArray
+  def binNamesOnly(fieldNames:Array[String], metaFields:Set[String]): Array[String] = {
+    fieldNames.toSet.diff(metaFields).toArray.sortWith(_ < _)
   }
 
   def metaFields(aerospikeConfig: AerospikeConfig): Set[String] = {
-    Set(aerospikeConfig.keyColumn(),
+    Set(
+      aerospikeConfig.keyColumn(),
       aerospikeConfig.digestColumn(),
       aerospikeConfig.expiryColumn(),
       aerospikeConfig.generationColumn(),
@@ -42,86 +28,72 @@ object TypeConverter{
   }
 
   def binToValue(schema: StructType, bin: (String, Object)): Any = {
+    val (binName, binVal) = bin
 
-    val binVal = bin._2
-    val binName = bin._1
-    //println(s"binToValue - name:$binName = value:$binVal")
-
-    val value = schema(binName).dataType match {
-      case _: LongType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].longValue
-      case _: IntegerType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].intValue
-      case _: DoubleType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].doubleValue()
-      case _: ArrayType => {
-        if (binVal == null) null else
-          //println(binVal.getClass.getCanonicalName)
-          binVal
-      }
-      case _: MapType => if (binVal == null) null else binVal.asInstanceOf[java.util.Map[Any,Any]].asScala
-      case null => null
-      case _ => if (binVal == null) null else binVal.toString()
+    Option(schema(binName).dataType) match {
+      case Some(value) =>
+        value match {
+          case _: LongType => Option(binVal).map(_.asInstanceOf[java.lang.Number].longValue()).orNull
+          case _: IntegerType => Option(binVal).map(_.asInstanceOf[java.lang.Number].intValue()).orNull
+          case _: DoubleType =>  Option(binVal).map(_.asInstanceOf[java.lang.Number].doubleValue()).orNull
+          case _: ArrayType => binVal
+          case _: MapType => Option(binVal).map(_.asInstanceOf[java.util.Map[Any,Any]].asScala).orNull
+          case null => null
+          case _ => Option(binVal).map(_.toString).orNull
+        }
+      case None => null
     }
-    value
   }
 
-  def fieldToBin(schema: StructType, row:Row, field:String): Bin = {
-
-    val value = row(schema.fieldIndex(field))
-    if (value == null) {
-      Bin.asNull(field)
-    } else {
-      schema(field).dataType match {
-        case StringType => new Bin(field, value)
-        case LongType => new Bin(field, value.asInstanceOf[java.lang.Long])
-        case IntegerType => new Bin(field, new java.lang.Long(value.asInstanceOf[Int]))
-        case ShortType => new Bin(field, value.asInstanceOf[java.lang.Long])
-        case DoubleType => new Bin(field, value.asInstanceOf[java.lang.Double])
-        case FloatType => new Bin(field, value.asInstanceOf[java.lang.Double])
-        case DateType => new Bin(field, value.asInstanceOf[java.sql.Date].getTime)
-        case NullType => Bin.asNull(field)
-        case _: ArrayType => {
-          value match {
-            case _: WrappedArray[Any] => new Bin(field, value.asInstanceOf[WrappedArray[Any]].toList.asJava)
-            case _: Seq[Any] => new Bin(field, scala.collection.JavaConversions.seqAsJavaList(value.asInstanceOf[Seq[Any]]))
-            case _: List[Any] => new Bin(field, value)
-          }
+  def fieldToBin(schema: StructType, row:Row, field: String): Bin = {
+    Option(row(schema.fieldIndex(field))) match {
+      case None => Bin.asNull(field)
+      case Some(value) =>
+        schema(field).dataType match {
+          case StringType => new Bin(field, value)
+          case LongType => new Bin(field, value.asInstanceOf[java.lang.Long])
+          case IntegerType => new Bin(field, new java.lang.Long(value.asInstanceOf[Int]))
+          case ShortType => new Bin(field, value.asInstanceOf[java.lang.Long])
+          case DoubleType => new Bin(field, value.asInstanceOf[java.lang.Double])
+          case FloatType => new Bin(field, value.asInstanceOf[java.lang.Double])
+          case DateType => new Bin(field, value.asInstanceOf[java.sql.Date].getTime)
+          case NullType => Bin.asNull(field)
+          case _: ArrayType =>
+            value match {
+              case _: mutable.WrappedArray[Any] => new Bin(field, value.asInstanceOf[mutable.WrappedArray[Any]].toList.asJava)
+              case _: Seq[Any] => new Bin(field, scala.collection.JavaConversions.seqAsJavaList(value.asInstanceOf[Seq[Any]]))
+              case _: List[Any] => new Bin(field, value)
+            }
+          case _: MapType =>
+            value match {
+              case _: scala.collection.Map[Any, Any] => new Bin(field, value.asInstanceOf[scala.collection.Map[Any, Any]].asJava)
+            }
+          case _ => new Bin(field, value.toString)
         }
-        case _: MapType => {
-          value match {
-            case _: scala.collection.Map[Any, Any] => new Bin(field, value.asInstanceOf[scala.collection.Map[Any, Any]].asJava)
-          }
-        }
-        case null => Bin.asNull(field)
-        case _ => new Bin(field, value.toString())
       }
-    }
   }
 
   def valueToSchema(bin: (String, Object)): StructField = {
+    val (binName, binVal) = bin
 
-    val binVal = bin._2
-    val binName = bin._1
-    val field = binVal match {
+    binVal match {
       case _: java.lang.Integer => StructField(binName, LongType, nullable = true)
       case _: java.lang.Short => StructField(binName, LongType, nullable = true)
       case _: java.lang.Long => StructField(binName, LongType, nullable = true)
       case _: java.lang.Double => StructField(binName, DoubleType, nullable = true)
       case _: java.lang.Float => StructField(binName, DoubleType, nullable = true)
-      case s: String => StructField(binName, StringType, nullable = true)
-      case _: java.util.Map[Object,Object] => {
+      case _: String => StructField(binName, StringType, nullable = true)
+      case _: java.util.Map[Object,Object] =>
         val aKey = valueToSchema((binName, binVal.asInstanceOf[java.util.Map[Object, Object]].asScala.keys.head))
         val aValue = valueToSchema((binName, binVal.asInstanceOf[java.util.Map[Object, Object]].asScala.values.head))
         StructField(binName, new MapType(aKey.dataType, aValue.dataType, true), nullable = true)
-      }
-      case _: java.util.List[Object] => {
+      case _: java.util.List[Object] =>
         val newValue = binVal.asInstanceOf[java.util.List[Object]].get(0)
         val elementStructure = valueToSchema((binName, newValue))
         StructField(binName, new ArrayType(elementStructure.dataType , true))
-      }
       //case ParticleType.GEOJSON => StructField(binName, StringType, nullable = true) //TODO
       case Array => StructField(binName, BinaryType, nullable = true)
       case _ => StructField(binName, BinaryType, nullable = true)
     }
-    field
   }
-
 }

--- a/src/main/scala/com/aerospike/spark/sql/TypeConverter.scala
+++ b/src/main/scala/com/aerospike/spark/sql/TypeConverter.scala
@@ -23,105 +23,105 @@ import com.aerospike.client.Bin
 
 
 /**
- * This object provides utility methods to convert between
- * the Aerospike and park SQL types
- */
+  * This object provides utility methods to convert between
+  * the Aerospike and park SQL types
+  */
 object TypeConverter{
-  
+
   def binNamesOnly(fieldNames:Array[String], metaFields:Set[String]):Array[String] = {
     val binsOnly = fieldNames.toSet.diff(metaFields).toSeq.sortWith(_ < _)
     binsOnly.toArray
   }
 
-  def metaFields(aerospikeConfig: AerospikeConfig): Set[String] = { 
+  def metaFields(aerospikeConfig: AerospikeConfig): Set[String] = {
     Set(aerospikeConfig.keyColumn(),
-        aerospikeConfig.digestColumn(), 
-        aerospikeConfig.expiryColumn(), 
-        aerospikeConfig.generationColumn(), 
-        aerospikeConfig.ttlColumn())
+      aerospikeConfig.digestColumn(),
+      aerospikeConfig.expiryColumn(),
+      aerospikeConfig.generationColumn(),
+      aerospikeConfig.ttlColumn())
   }
-  
+
   def binToValue(schema: StructType, bin: (String, Object)): Any = {
-    
-		val binVal = bin._2
-		val binName = bin._1
-		//println(s"binToValue - name:$binName = value:$binVal")
-		
+
+    val binVal = bin._2
+    val binName = bin._1
+    //println(s"binToValue - name:$binName = value:$binVal")
+
     val value = schema(binName).dataType match {
-		  case _: LongType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].longValue
-		  case _: IntegerType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].intValue
-		  case _: DoubleType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].doubleValue()
-		  case _: ArrayType => {
-		    if (binVal == null) null else 
-		      //println(binVal.getClass.getCanonicalName)
-		      binVal
-		  }
-		  case _: MapType => if (binVal == null) null else binVal.asInstanceOf[java.util.Map[Any,Any]].asScala
-		  case null => null
-		  case _ => if (binVal == null) null else binVal.toString()
-		}
+      case _: LongType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].longValue
+      case _: IntegerType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].intValue
+      case _: DoubleType => if (binVal == null) null else binVal.asInstanceOf[java.lang.Number].doubleValue()
+      case _: ArrayType => {
+        if (binVal == null) null else
+          //println(binVal.getClass.getCanonicalName)
+          binVal
+      }
+      case _: MapType => if (binVal == null) null else binVal.asInstanceOf[java.util.Map[Any,Any]].asScala
+      case null => null
+      case _ => if (binVal == null) null else binVal.toString()
+    }
     value
   }
-  
+
   def fieldToBin(schema: StructType, row:Row, field:String): Bin = {
-    
-		val value = row(schema.fieldIndex(field))
-		if (value == null) {
-		  Bin.asNull(field)
-		} else {
+
+    val value = row(schema.fieldIndex(field))
+    if (value == null) {
+      Bin.asNull(field)
+    } else {
       schema(field).dataType match {
         case StringType => new Bin(field, value)
-  		  case LongType => new Bin(field, value.asInstanceOf[java.lang.Long])
-  		  case IntegerType => new Bin(field, new java.lang.Long(value.asInstanceOf[Int]))
-  		  case ShortType => new Bin(field, value.asInstanceOf[java.lang.Long])
-  		  case DoubleType => new Bin(field, value.asInstanceOf[java.lang.Double])
-  		  case FloatType => new Bin(field, value.asInstanceOf[java.lang.Double])
-  		  case DateType => new Bin(field, value.asInstanceOf[java.sql.Date].getTime)
-  		  case NullType => Bin.asNull(field)
-  		  case _: ArrayType => {
-  		    value match {
-  		      case _: WrappedArray[Any] => new Bin(field, value.asInstanceOf[WrappedArray[Any]].toList.asJava)
-  		      case _: Seq[Any] => new Bin(field, scala.collection.JavaConversions.seqAsJavaList(value.asInstanceOf[Seq[Any]]))
-  		      case _: List[Any] => new Bin(field, value)
-  		    }
-  		  }
-  		  case _: MapType => {
-  		    value match {
-  		      case _: scala.collection.Map[Any, Any] => new Bin(field, value.asInstanceOf[scala.collection.Map[Any, Any]].asJava)
-  		    }
-  		  }
-  		  case null => Bin.asNull(field)
-  		  case _ => new Bin(field, value.toString())
+        case LongType => new Bin(field, value.asInstanceOf[java.lang.Long])
+        case IntegerType => new Bin(field, new java.lang.Long(value.asInstanceOf[Int]))
+        case ShortType => new Bin(field, value.asInstanceOf[java.lang.Long])
+        case DoubleType => new Bin(field, value.asInstanceOf[java.lang.Double])
+        case FloatType => new Bin(field, value.asInstanceOf[java.lang.Double])
+        case DateType => new Bin(field, value.asInstanceOf[java.sql.Date].getTime)
+        case NullType => Bin.asNull(field)
+        case _: ArrayType => {
+          value match {
+            case _: WrappedArray[Any] => new Bin(field, value.asInstanceOf[WrappedArray[Any]].toList.asJava)
+            case _: Seq[Any] => new Bin(field, scala.collection.JavaConversions.seqAsJavaList(value.asInstanceOf[Seq[Any]]))
+            case _: List[Any] => new Bin(field, value)
+          }
         }
-  		}
+        case _: MapType => {
+          value match {
+            case _: scala.collection.Map[Any, Any] => new Bin(field, value.asInstanceOf[scala.collection.Map[Any, Any]].asJava)
+          }
+        }
+        case null => Bin.asNull(field)
+        case _ => new Bin(field, value.toString())
+      }
+    }
   }
-  
-	def valueToSchema(bin: (String, Object)): StructField = {
 
-			val binVal = bin._2
-			val binName = bin._1
-			val field = binVal match {
-					case _: java.lang.Integer => StructField(binName, LongType, nullable = true)
-					case _: java.lang.Short => StructField(binName, LongType, nullable = true)
-					case _: java.lang.Long => StructField(binName, LongType, nullable = true)
-					case _: java.lang.Double => StructField(binName, DoubleType, nullable = true)
-					case _: java.lang.Float => StructField(binName, DoubleType, nullable = true)
-					case s: String => StructField(binName, StringType, nullable = true)
-					case _: java.util.Map[Object,Object] => {
-					  val aKey = valueToSchema((binName, binVal.asInstanceOf[java.util.Map[Object, Object]].asScala.keys.head))
-					  val aValue = valueToSchema((binName, binVal.asInstanceOf[java.util.Map[Object, Object]].asScala.values.head))
-					  StructField(binName, new MapType(aKey.dataType, aValue.dataType, true), nullable = true) 
-					}
-					case _: java.util.List[Object] => { 
-					  val newValue = binVal.asInstanceOf[java.util.List[Object]].get(0)
-					  val elementStructure = valueToSchema((binName, newValue))
-					  StructField(binName, new ArrayType(elementStructure.dataType , true)) 
-					}
-					//case ParticleType.GEOJSON => StructField(binName, StringType, nullable = true) //TODO 
-					case Array => StructField(binName, BinaryType, nullable = true)
-					case _ => StructField(binName, BinaryType, nullable = true)
-			} 
-			field
-	}
-	
+  def valueToSchema(bin: (String, Object)): StructField = {
+
+    val binVal = bin._2
+    val binName = bin._1
+    val field = binVal match {
+      case _: java.lang.Integer => StructField(binName, LongType, nullable = true)
+      case _: java.lang.Short => StructField(binName, LongType, nullable = true)
+      case _: java.lang.Long => StructField(binName, LongType, nullable = true)
+      case _: java.lang.Double => StructField(binName, DoubleType, nullable = true)
+      case _: java.lang.Float => StructField(binName, DoubleType, nullable = true)
+      case s: String => StructField(binName, StringType, nullable = true)
+      case _: java.util.Map[Object,Object] => {
+        val aKey = valueToSchema((binName, binVal.asInstanceOf[java.util.Map[Object, Object]].asScala.keys.head))
+        val aValue = valueToSchema((binName, binVal.asInstanceOf[java.util.Map[Object, Object]].asScala.values.head))
+        StructField(binName, new MapType(aKey.dataType, aValue.dataType, true), nullable = true)
+      }
+      case _: java.util.List[Object] => {
+        val newValue = binVal.asInstanceOf[java.util.List[Object]].get(0)
+        val elementStructure = valueToSchema((binName, newValue))
+        StructField(binName, new ArrayType(elementStructure.dataType , true))
+      }
+      //case ParticleType.GEOJSON => StructField(binName, StringType, nullable = true) //TODO
+      case Array => StructField(binName, BinaryType, nullable = true)
+      case _ => StructField(binName, BinaryType, nullable = true)
+    }
+    field
+  }
+
 }

--- a/src/test/scala/com/aerospike/spark/sql/AerospikeConnectionTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/AerospikeConnectionTest.scala
@@ -16,7 +16,7 @@ class AerospikeConnectionTest extends FlatSpec {
   var config: AerospikeConfig = _
 
   behavior of "AerospikeConnection"
-  
+
   it should " test Client witnout Spark" in {
     config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
     var client = AerospikeConnection.getClient(config)
@@ -24,15 +24,15 @@ class AerospikeConnectionTest extends FlatSpec {
     for (i <- 1 to 100) {
       val key = new Key(Globals.namespace, "rdd-test", "rdd-test-"+i)
       client.put(null, key,
-         new Bin("one", i),
-         new Bin("two", "two:"+i),
-         new Bin("three", i.asInstanceOf[Double])
+        new Bin("one", i),
+        new Bin("two", "two:"+i),
+        new Bin("three", i.asInstanceOf[Double])
       )
       client.get(null, key)
       client.delete(null, key)
     }
   }
-  
+
   it should " test Client with Spark" in {
     conf = new SparkConf().setMaster("local[*]").setAppName("Aerospike RDD Tests")
     sc = new SparkContext(conf)
@@ -42,60 +42,60 @@ class AerospikeConnectionTest extends FlatSpec {
     for (i <- 1 to 100) {
       val key = new Key(Globals.namespace, "rdd-test", "rdd-test-"+i)
       client.put(null, key,
-         new Bin("one", i),
-         new Bin("two", "two:"+i),
-         new Bin("three", i.asInstanceOf[Double])
+        new Bin("one", i),
+        new Bin("two", "two:"+i),
+        new Bin("three", i.asInstanceOf[Double])
       )
     }
   }
-  
+
   it should " test Client with Spark and Config" in {
-    
+
     config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
     var client = AerospikeConnection.getClient(config)
 
     for (i <- 1 to 100) {
       val key = new Key(Globals.namespace, "rdd-test", "rdd-test-"+i)
       client.put(null, key,
-         new Bin("one", i),
-         new Bin("two", "two:"+i),
-         new Bin("three", i.asInstanceOf[Double])
+        new Bin("one", i),
+        new Bin("two", "two:"+i),
+        new Bin("three", i.asInstanceOf[Double])
       )
     }
   }
   it should " test QueryEngine with spark" in {
-     var qe = AerospikeConnection.getQueryEngine(config)
-     
-     var stmt = new Statement()
-     stmt.setNamespace(Globals.namespace)
-     stmt.setSetName("rdd-test")
-     val kri = qe.select(stmt)
-     var count = 0
-     print("\t")
-     while (kri.hasNext())
-       //println(kri.next())
-       print(".")
-     qe.close()
-    
+    var qe = AerospikeConnection.getQueryEngine(config)
+
+    var stmt = new Statement()
+    stmt.setNamespace(Globals.namespace)
+    stmt.setSetName("rdd-test")
+    val kri = qe.select(stmt)
+    var count = 0
+    print("\t")
+    while (kri.hasNext())
+      //println(kri.next())
+      print(".")
+    qe.close()
+
   }
   it should " do it multiple time" in {
     for( a <- 1 to 10){
-     
-     val qe = AerospikeConnection.getQueryEngine(config)
-     
-     var stmt = new Statement()
-     stmt.setNamespace(Globals.namespace)
-     stmt.setSetName("rdd-test")
-     val kri = qe.select(stmt)
-     var count = 0
-     print("\t")
-     while (kri.hasNext())
-       //println(kri.next())
-       print(".")
+
+      val qe = AerospikeConnection.getQueryEngine(config)
+
+      var stmt = new Statement()
+      stmt.setNamespace(Globals.namespace)
+      stmt.setSetName("rdd-test")
+      val kri = qe.select(stmt)
+      var count = 0
+      print("\t")
+      while (kri.hasNext())
+        //println(kri.next())
+        print(".")
       qe.close()
-    println(s"\tIteration: $a")
+      println(s"\tIteration: $a")
     }
-    
+
   }
 
 }

--- a/src/test/scala/com/aerospike/spark/sql/AerospikeConnectionTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/AerospikeConnectionTest.scala
@@ -3,23 +3,24 @@ package com.aerospike.spark.sql
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
-import com.aerospike.client.AerospikeClient
 import org.scalatest.FlatSpec
 import com.aerospike.client.Key
 import com.aerospike.client.Bin
 import com.aerospike.client.query.Statement
 
+/*
+ * TODO: There's nothing tested here.
+ */
 class AerospikeConnectionTest extends FlatSpec {
   var conf: SparkConf = _
-  var sc:SparkContext = _
+  var sc: SparkContext = _
   var sqlContext: SQLContext = _
-  var config: AerospikeConfig = _
+  val config: AerospikeConfig = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
 
   behavior of "AerospikeConnection"
 
-  it should " test Client witnout Spark" in {
-    config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
-    var client = AerospikeConnection.getClient(config)
+  it should " test Client without Spark" in {
+    val client = AerospikeConnection.getClient(config)
 
     for (i <- 1 to 100) {
       val key = new Key(Globals.namespace, "rdd-test", "rdd-test-"+i)
@@ -37,7 +38,7 @@ class AerospikeConnectionTest extends FlatSpec {
     conf = new SparkConf().setMaster("local[*]").setAppName("Aerospike RDD Tests")
     sc = new SparkContext(conf)
     sqlContext = new SQLContext(sc)
-    var client = AerospikeConnection.getClient(config)
+    val client = AerospikeConnection.getClient(config)
 
     for (i <- 1 to 100) {
       val key = new Key(Globals.namespace, "rdd-test", "rdd-test-"+i)
@@ -50,9 +51,7 @@ class AerospikeConnectionTest extends FlatSpec {
   }
 
   it should " test Client with Spark and Config" in {
-
-    config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
-    var client = AerospikeConnection.getClient(config)
+    val client = AerospikeConnection.getClient(config)
 
     for (i <- 1 to 100) {
       val key = new Key(Globals.namespace, "rdd-test", "rdd-test-"+i)
@@ -64,38 +63,32 @@ class AerospikeConnectionTest extends FlatSpec {
     }
   }
   it should " test QueryEngine with spark" in {
-    var qe = AerospikeConnection.getQueryEngine(config)
+    val qe = AerospikeConnection.getQueryEngine(config)
 
-    var stmt = new Statement()
+    val stmt = new Statement()
     stmt.setNamespace(Globals.namespace)
     stmt.setSetName("rdd-test")
     val kri = qe.select(stmt)
-    var count = 0
     print("\t")
-    while (kri.hasNext())
-      //println(kri.next())
+    while (kri.hasNext)
       print(".")
     qe.close()
-
   }
+
   it should " do it multiple time" in {
     for( a <- 1 to 10){
-
       val qe = AerospikeConnection.getQueryEngine(config)
-
-      var stmt = new Statement()
+      val stmt = new Statement()
       stmt.setNamespace(Globals.namespace)
       stmt.setSetName("rdd-test")
       val kri = qe.select(stmt)
       var count = 0
       print("\t")
-      while (kri.hasNext())
+      while (kri.hasNext)
         //println(kri.next())
         print(".")
       qe.close()
       println(s"\tIteration: $a")
     }
-
   }
-
 }

--- a/src/test/scala/com/aerospike/spark/sql/AerospikeRelationTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/AerospikeRelationTest.scala
@@ -1,9 +1,6 @@
 package com.aerospike.spark.sql
 
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.types.StructType
 import org.scalatest.FlatSpec
 
@@ -22,29 +19,14 @@ import org.apache.spark.sql.SaveMode
 import com.aerospike.client.policy.WritePolicy
 
 
-class AerospikeRelationTest extends FlatSpec with BeforeAndAfter {
+class AerospikeRelationTest extends FlatSpec with BeforeAndAfter with SparkTest {
+  val config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
   var client: AerospikeClient = _
-  var conf: SparkConf = _
-  var sc:SparkContext = _
-  var sqlContext: SQLContext = _
 
   val TEST_COUNT = 100
 
-  val config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
-
   before {
-    conf = new SparkConf().setMaster("local[*]")
-      .setAppName("Aerospike Relation Tests")
-      .set("spark.driver.allowMultipleContexts", "true")
-    sc = new SparkContext(conf)
-    sqlContext = new SQLContext(sc)
     createTestData()
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
   }
 
   def createTestData() = {

--- a/src/test/scala/com/aerospike/spark/sql/AerospikeRelationTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/AerospikeRelationTest.scala
@@ -2,10 +2,8 @@ package com.aerospike.spark.sql
 
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types.StructType
 import org.scalatest.FlatSpec
 
@@ -16,23 +14,19 @@ import com.aerospike.client.Value
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.types.StringType
-import org.apache.spark.sql.functions.lit
 import org.scalatest.BeforeAndAfter
 import org.apache.spark.sql.types.IntegerType
 import org.joda.time.format.DateTimeFormat
-import org.joda.time.DateTime
 import org.apache.spark.sql.SaveMode
 
-import org.apache.spark.sql.functions._
 import com.aerospike.client.policy.WritePolicy
 
 
-class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
+class AerospikeRelationTest extends FlatSpec with BeforeAndAfter {
   var client: AerospikeClient = _
   var conf: SparkConf = _
   var sc:SparkContext = _
   var sqlContext: SQLContext = _
-  var thingsDF: DataFrame = _
 
   val TEST_COUNT = 100
 
@@ -44,7 +38,7 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
       .set("spark.driver.allowMultipleContexts", "true")
     sc = new SparkContext(conf)
     sqlContext = new SQLContext(sc)
-
+    createTestData()
   }
 
   after {
@@ -53,10 +47,7 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
     }
   }
 
-  behavior of "Aerospike Relation"
-
-
-  it should "create test data" in {
+  def createTestData() = {
     client = AerospikeConnection.getClient(config)
     Value.UseDoubleType = true
     val wp = new WritePolicy()
@@ -71,14 +62,16 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
     }
   }
 
+  behavior of "Aerospike Relation"
+
   it should "create an AerospikeRelation" in {
-    thingsDF = sqlContext.read.
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "rdd-test").
-      load
+    val thingsDF = sqlContext.read
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "rdd-test")
+      .load
     //thingsDF.printSchema()
     val result = thingsDF.take(50)
     result.foreach { row =>
@@ -87,13 +80,13 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
   }
 
   it should " select the data using filter on 'one'" in {
-    thingsDF = sqlContext.read.
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "rdd-test").
-      load
+    val thingsDF = sqlContext.read
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "rdd-test")
+      .load
     thingsDF.registerTempTable("things")
     val filteredThings = sqlContext.sql("select * from things where one = 55")
     val count = filteredThings.count()
@@ -104,13 +97,13 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
   }
 
   it should " select the data using range filter where 'one' is between 55 and 65" in {
-    thingsDF = sqlContext.read.
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "rdd-test").
-      load
+    val thingsDF = sqlContext.read
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "rdd-test")
+      .load
     thingsDF.registerTempTable("things")
     val filteredThings = sqlContext.sql("select * from things where one between 55 and 65")
     val count = filteredThings.count()
@@ -123,41 +116,41 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
 
 
   it should "save with Overwrite (RecordExistsAction.REPLACE)" in {
-    thingsDF = sqlContext.read.
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "rdd-test").
-      load
-    thingsDF.write.
-      mode(SaveMode.Overwrite).
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "rdd-test").
-      option("aerospike.updateByDigest", "__digest").
-      save()
+    val thingsDF = sqlContext.read
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "rdd-test")
+      .load
+    thingsDF.write
+      .mode(SaveMode.Overwrite)
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "rdd-test")
+      .option("aerospike.updateByDigest", "__digest")
+      .save()
   }
 
   it should "save with Ignore (RecordExistsAction.CREATE_ONLY)" in {
-    thingsDF = sqlContext.read.
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "rdd-test").
-      load
-    thingsDF.write.
-      mode(SaveMode.Ignore).
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "rdd-test").
-      option("aerospike.updateByDigest", "__digest").
-      save()
+    val thingsDF = sqlContext.read
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "rdd-test")
+      .load
+    thingsDF.write
+      .mode(SaveMode.Ignore)
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "rdd-test")
+      .option("aerospike.updateByDigest", "__digest")
+      .save()
   }
 
   it should "write data from DataFrame with expiry" in {
@@ -186,16 +179,16 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
 
     val newDF = sqlContext.createDataFrame(inputRDD, schema)
 
-    newDF.write.
-      mode(SaveMode.Ignore).
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", setName).
-      option("aerospike.updateByKey", "key").
-      option("aerospike.ttlColumn", "ttl").  // new time to live from column
-      save()
+    newDF.write
+      .mode(SaveMode.Ignore)
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", setName)
+      .option("aerospike.updateByKey", "key")
+      .option("aerospike.ttlColumn", "ttl")  // new time to live from colum
+      .save()
 
     var key = new Key(Globals.namespace, setName, "Fraser_Malcolm")
     var record = client.get(null, key)
@@ -208,7 +201,6 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
     key = new Key(Globals.namespace, setName, "Gillard_Julia")
     record = client.get(null, key)
     assert(record.getLong("when") == 2010)
-
   }
 
   it should "write and read a lot of data" in {
@@ -225,29 +217,29 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
       val flightsRDD = rawFlightsRDD
         .filter(!_.contains("YEAR")) // Ignore headers
         .map(_.replace("\"", ""))
-        .map(Flight.assign(_))
+        .map(Flight.assign)
         .filter(_.DEP_TIME != null) // flights that never depart
         .filter(_.ARR_TIME != null) // flights that never arrive
 
       /*
        * make a DataFrame from the RDD
        */
-      var flightsDF = sqlContext.createDataFrame(flightsRDD)
+      val flightsDF = sqlContext.createDataFrame(flightsRDD)
 
       //flightsDF.printSchema()
       //flightsDF.show(50)
 
       println("Save flights to Aerospike")
-      flightsDF.write.
-        mode(SaveMode.Overwrite).
-        format("com.aerospike.spark.sql").
-        option("aerospike.seedhost", Globals.seedHost).
-        option("aerospike.port", Globals.port.toString).
-        option("aerospike.namespace", Globals.namespace).
-        option("aerospike.set", "spark-test").
-        option("aerospike.updateByKey", "key").
-        option("aerospike.ttlColumn", "expiry").
-        save()
+      flightsDF.write
+        .mode(SaveMode.Overwrite)
+        .format("com.aerospike.spark.sql")
+        .option("aerospike.seedhost", Globals.seedHost)
+        .option("aerospike.port", Globals.port.toString)
+        .option("aerospike.namespace", Globals.namespace)
+        .option("aerospike.set", "spark-test")
+        .option("aerospike.updateByKey", "key")
+        .option("aerospike.ttlColumn", "expiry")
+        .save()
 
       println("flights saved")
     }
@@ -255,13 +247,13 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
      * find all the flights that are > 5 minutes late
      */
     println("Find late flights from Aerospike")
-    val readFlightsDF = sqlContext.read.
-      format("com.aerospike.spark.sql").
-      option("aerospike.seedhost", Globals.seedHost).
-      option("aerospike.port", Globals.port.toString).
-      option("aerospike.namespace", Globals.namespace).
-      option("aerospike.set", "spark-test").
-      load
+    val readFlightsDF = sqlContext.read
+      .format("com.aerospike.spark.sql")
+      .option("aerospike.seedhost", Globals.seedHost)
+      .option("aerospike.port", Globals.port.toString)
+      .option("aerospike.namespace", Globals.namespace)
+      .option("aerospike.set", "spark-test")
+      .load
 
     //readFlightsDF.printSchema()
     readFlightsDF.registerTempTable("Flights")
@@ -271,7 +263,6 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
 
     //lateFlightsDF.show(10)
     assert(12907 == lateFlightsDF.count())
-
   }
 }
 
@@ -306,7 +297,7 @@ object Flight{
   def assign(csvRow: String): Flight = {
 
     val values = csvRow.split(",")
-    var flight = new Flight(
+    val flight = new Flight(
       values(0).toInt,
       values(1).toInt,
       values(2).toInt,

--- a/src/test/scala/com/aerospike/spark/sql/AerospikeRelationTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/AerospikeRelationTest.scala
@@ -33,15 +33,15 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
   var sc:SparkContext = _
   var sqlContext: SQLContext = _
   var thingsDF: DataFrame = _
-  
+
   val TEST_COUNT = 100
-  
+
   val config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 10000)
-  
+
   before {
     conf = new SparkConf().setMaster("local[*]")
-        .setAppName("Aerospike Relation Tests")
-        .set("spark.driver.allowMultipleContexts", "true")
+      .setAppName("Aerospike Relation Tests")
+      .set("spark.driver.allowMultipleContexts", "true")
     sc = new SparkContext(conf)
     sqlContext = new SQLContext(sc)
 
@@ -55,7 +55,7 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
 
   behavior of "Aerospike Relation"
 
-  
+
   it should "create test data" in {
     client = AerospikeConnection.getClient(config)
     Value.UseDoubleType = true
@@ -64,301 +64,301 @@ class AerospikeRelationTest extends FlatSpec with BeforeAndAfter{
     for (i <- 1 to TEST_COUNT) {
       val key = new Key(Globals.namespace, "rdd-test", s"rdd-test-$i")
       client.put(wp, key,
-         new Bin("one", i),
-         new Bin("two", s"two:$i"),
-         new Bin("three", i.toDouble)
+        new Bin("one", i),
+        new Bin("two", s"two:$i"),
+        new Bin("three", i.toDouble)
       )
     }
   }
-  
+
   it should "create an AerospikeRelation" in {
-		thingsDF = sqlContext.read.
-						format("com.aerospike.spark.sql").
-						option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", "rdd-test").
-						load 
-	  //thingsDF.printSchema()
-		val result = thingsDF.take(50)
-		result.foreach { row => 
-		    assert(row.getAs[String]("two").startsWith("two:"))
+    thingsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "rdd-test").
+      load
+    //thingsDF.printSchema()
+    val result = thingsDF.take(50)
+    result.foreach { row =>
+      assert(row.getAs[String]("two").startsWith("two:"))
     }
   }
-  
+
   it should " select the data using filter on 'one'" in {
-		thingsDF = sqlContext.read.
-						format("com.aerospike.spark.sql").
-						option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", "rdd-test").
-						load 
-		thingsDF.registerTempTable("things")
-		val filteredThings = sqlContext.sql("select * from things where one = 55")
-		val count = filteredThings.count()
-		assert(count > 0)
-		val thing = filteredThings.first()
-		val one = thing.getAs[Long]("one")
-		assert(one == 55)
+    thingsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "rdd-test").
+      load
+    thingsDF.registerTempTable("things")
+    val filteredThings = sqlContext.sql("select * from things where one = 55")
+    val count = filteredThings.count()
+    assert(count > 0)
+    val thing = filteredThings.first()
+    val one = thing.getAs[Long]("one")
+    assert(one == 55)
   }
 
   it should " select the data using range filter where 'one' is between 55 and 65" in {
-		thingsDF = sqlContext.read.
-						format("com.aerospike.spark.sql").
-						option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", "rdd-test").
-						load 
-		thingsDF.registerTempTable("things")
-		val filteredThings = sqlContext.sql("select * from things where one between 55 and 65")
-		val count = filteredThings.count()
-		assert(count > 0)
-		val thing = filteredThings.first()
-		val one = thing.getAs[Long]("one")
-		assert(one >= 55)
-		assert(one <= 65)
+    thingsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "rdd-test").
+      load
+    thingsDF.registerTempTable("things")
+    val filteredThings = sqlContext.sql("select * from things where one between 55 and 65")
+    val count = filteredThings.count()
+    assert(count > 0)
+    val thing = filteredThings.first()
+    val one = thing.getAs[Long]("one")
+    assert(one >= 55)
+    assert(one <= 65)
   }
 
-  
+
   it should "save with Overwrite (RecordExistsAction.REPLACE)" in {
-		thingsDF = sqlContext.read.
-						format("com.aerospike.spark.sql").
-						option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", "rdd-test").
-						load 
+    thingsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "rdd-test").
+      load
     thingsDF.write.
-        mode(SaveMode.Overwrite).
-        format("com.aerospike.spark.sql").
-        option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", "rdd-test").
-						option("aerospike.updateByDigest", "__digest").
-        save()                
+      mode(SaveMode.Overwrite).
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "rdd-test").
+      option("aerospike.updateByDigest", "__digest").
+      save()
   }
 
   it should "save with Ignore (RecordExistsAction.CREATE_ONLY)" in {
-		thingsDF = sqlContext.read.
-						format("com.aerospike.spark.sql").
-						option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", "rdd-test").
-						load 
+    thingsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "rdd-test").
+      load
     thingsDF.write.
-        mode(SaveMode.Ignore).
-        format("com.aerospike.spark.sql").
-        option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", "rdd-test").
-						option("aerospike.updateByDigest", "__digest").
-        save()                
+      mode(SaveMode.Ignore).
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "rdd-test").
+      option("aerospike.updateByDigest", "__digest").
+      save()
   }
-  
+
   it should "write data from DataFrame with expiry" in {
-      
-      val setName = "new-rdd-data"
-      
-      val schema = new StructType(Array(
-          StructField("key",StringType,nullable = false),
-          StructField("last",StringType,nullable = true),
-          StructField("first",StringType,nullable = true),
-          StructField("when",LongType,nullable = true),
-          StructField("ttl", IntegerType, nullable = true)
-          )) 
-      val rows = Seq(
-          Row("Fraser_Malcolm","Fraser", "Malcolm", 1975L, 600),
-          Row("Hawke_Bob","Hawke", "Bob", 1983L, 600),
-          Row("Keating_Paul","Keating", "Paul", 1991L, 600), 
-          Row("Howard_John","Howard", "John", 1996L, 600), 
-          Row("Rudd_Kevin","Rudd", "Kevin", 2007L, 600), 
-          Row("Gillard_Julia","Gillard", "Julia", 2010L, 600), 
-          Row("Abbott_Tony","Abbott", "Tony", 2013L, 600), 
-          Row("Tunrbull_Malcom","Tunrbull", "Malcom", 2015L, 600)
-          )
-          
-      val inputRDD = sc.parallelize(rows)
-      
-      val newDF = sqlContext.createDataFrame(inputRDD, schema)
-  
-      newDF.write.
-        mode(SaveMode.Ignore).
+
+    val setName = "new-rdd-data"
+
+    val schema = new StructType(Array(
+      StructField("key",StringType,nullable = false),
+      StructField("last",StringType,nullable = true),
+      StructField("first",StringType,nullable = true),
+      StructField("when",LongType,nullable = true),
+      StructField("ttl", IntegerType, nullable = true)
+    ))
+    val rows = Seq(
+      Row("Fraser_Malcolm","Fraser", "Malcolm", 1975L, 600),
+      Row("Hawke_Bob","Hawke", "Bob", 1983L, 600),
+      Row("Keating_Paul","Keating", "Paul", 1991L, 600),
+      Row("Howard_John","Howard", "John", 1996L, 600),
+      Row("Rudd_Kevin","Rudd", "Kevin", 2007L, 600),
+      Row("Gillard_Julia","Gillard", "Julia", 2010L, 600),
+      Row("Abbott_Tony","Abbott", "Tony", 2013L, 600),
+      Row("Tunrbull_Malcom","Tunrbull", "Malcom", 2015L, 600)
+    )
+
+    val inputRDD = sc.parallelize(rows)
+
+    val newDF = sqlContext.createDataFrame(inputRDD, schema)
+
+    newDF.write.
+      mode(SaveMode.Ignore).
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", setName).
+      option("aerospike.updateByKey", "key").
+      option("aerospike.ttlColumn", "ttl").  // new time to live from column
+      save()
+
+    var key = new Key(Globals.namespace, setName, "Fraser_Malcolm")
+    var record = client.get(null, key)
+    assert(record.getString("last") == "Fraser")
+
+    key = new Key(Globals.namespace, setName, "Hawke_Bob")
+    record = client.get(null, key)
+    assert(record.getString("first") == "Bob")
+
+    key = new Key(Globals.namespace, setName, "Gillard_Julia")
+    record = client.get(null, key)
+    assert(record.getLong("when") == 2010)
+
+  }
+
+  it should "write and read a lot of data" in {
+    /*
+     * Read flights data from CSV file an load them if they don't exist
+     */
+    val checkKey: Key = new Key(Globals.namespace, "spark-test", Flight.formKey("2313", "AA", "655", "20151-1-10"))
+
+    if (!client.exists(null, checkKey)) {
+      val rawFlightsRDD = sc.textFile("data/flightsaa.csv")
+      /*
+       * Parse each line into a Flight case class RDD
+       */
+      val flightsRDD = rawFlightsRDD
+        .filter(!_.contains("YEAR")) // Ignore headers
+        .map(_.replace("\"", ""))
+        .map(Flight.assign(_))
+        .filter(_.DEP_TIME != null) // flights that never depart
+        .filter(_.ARR_TIME != null) // flights that never arrive
+
+      /*
+       * make a DataFrame from the RDD
+       */
+      var flightsDF = sqlContext.createDataFrame(flightsRDD)
+
+      //flightsDF.printSchema()
+      //flightsDF.show(50)
+
+      println("Save flights to Aerospike")
+      flightsDF.write.
+        mode(SaveMode.Overwrite).
         format("com.aerospike.spark.sql").
         option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", setName).
-						option("aerospike.updateByKey", "key").
-						option("aerospike.ttlColumn", "ttl").  // new time to live from column
-        save()       
-      
-      var key = new Key(Globals.namespace, setName, "Fraser_Malcolm")
-      var record = client.get(null, key)
-      assert(record.getString("last") == "Fraser")
-      
-      key = new Key(Globals.namespace, setName, "Hawke_Bob")
-      record = client.get(null, key)
-      assert(record.getString("first") == "Bob")
+        option("aerospike.port", Globals.port.toString).
+        option("aerospike.namespace", Globals.namespace).
+        option("aerospike.set", "spark-test").
+        option("aerospike.updateByKey", "key").
+        option("aerospike.ttlColumn", "expiry").
+        save()
 
-      key = new Key(Globals.namespace, setName, "Gillard_Julia")
-      record = client.get(null, key)
-      assert(record.getLong("when") == 2010)
+      println("flights saved")
+    }
+    /*
+     * find all the flights that are > 5 minutes late
+     */
+    println("Find late flights from Aerospike")
+    val readFlightsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", "spark-test").
+      load
 
-  }
-  
-  it should "write and read a lot of data" in {
-   /*
-	 * Read flights data from CSV file an load them if they don't exist
-	 */
-  val checkKey: Key = new Key(Globals.namespace, "spark-test", Flight.formKey("2313", "AA", "655", "20151-1-10"))
-      
-  if (!client.exists(null, checkKey)) {
-    val rawFlightsRDD = sc.textFile("data/flightsaa.csv")
-    /*
-     * Parse each line into a Flight case class RDD
-     */
-    val flightsRDD = rawFlightsRDD
-      	.filter(!_.contains("YEAR")) // Ignore headers
-      	.map(_.replace("\"", ""))
-      	.map(Flight.assign(_))
-      	.filter(_.DEP_TIME != null) // flights that never depart
-      	.filter(_.ARR_TIME != null) // flights that never arrive
-      	    
-    /*
-     * make a DataFrame from the RDD 
-     */
-    var flightsDF = sqlContext.createDataFrame(flightsRDD)
-    
-    //flightsDF.printSchema()
-    //flightsDF.show(50)
-     
-    println("Save flights to Aerospike")
-    flightsDF.write.
-    	mode(SaveMode.Overwrite).
-    	format("com.aerospike.spark.sql").
-    	option("aerospike.seedhost", Globals.seedHost).
-    	option("aerospike.port", Globals.port.toString).
-    	option("aerospike.namespace", Globals.namespace).
-    	option("aerospike.set", "spark-test").
-    	option("aerospike.updateByKey", "key").
-    	option("aerospike.ttlColumn", "expiry").
-    	save()         
-    	
-    	println("flights saved")
-  }
-	/*
-	 * find all the flights that are > 5 minutes late
-	 */
-	println("Find late flights from Aerospike")
-	val readFlightsDF = sqlContext.read.
-  	format("com.aerospike.spark.sql").
-  	option("aerospike.seedhost", Globals.seedHost).
-  	option("aerospike.port", Globals.port.toString).
-  	option("aerospike.namespace", Globals.namespace).
-  	option("aerospike.set", "spark-test").
-  	load 
-	
-  //readFlightsDF.printSchema()
-	readFlightsDF.registerTempTable("Flights")
-	//readFlightsDF.show(1)
-	
-	val lateFlightsDF = sqlContext.sql("select CARRIER, FL_NUM, DEP_DELAY_NEW, ARR_DELAY_NEW from Flights where ARR_DELAY_NEW > 5")  
-	
-	//lateFlightsDF.show(10)
-   assert(12907 == lateFlightsDF.count())
+    //readFlightsDF.printSchema()
+    readFlightsDF.registerTempTable("Flights")
+    //readFlightsDF.show(1)
+
+    val lateFlightsDF = sqlContext.sql("select CARRIER, FL_NUM, DEP_DELAY_NEW, ARR_DELAY_NEW from Flights where ARR_DELAY_NEW > 5")
+
+    //lateFlightsDF.show(10)
+    assert(12907 == lateFlightsDF.count())
 
   }
 }
 
 case class Flight(
-		YEAR: Int,
-		MONTH: Int,
-		DAY_OF_MONTH: Int,
-		DAY_OF_WEEK: Int,
-		FL_DATE:java.sql.Date,
-		CARRIER: String,
-		TAIL_NUM: String,
-		FL_NUM: String,
-		ORIG_ID: Int,
-		ORIG_SEQ_ID: Int,
-		ORIGIN: String,
-		DEST_AP_ID: Int,
-		DEST: String,
-		DEP_TIME: java.sql.Date,
-		DEP_DELAY_NEW: Double,
-		ARR_TIME: java.sql.Date,
-		ARR_DELAY_NEW: Double,
-		ELAPSED_TIME: Double,
-		DISTANCE: Double,
-		key: String,
-		expiry: Int
-		) extends Serializable
+  YEAR: Int,
+  MONTH: Int,
+  DAY_OF_MONTH: Int,
+  DAY_OF_WEEK: Int,
+  FL_DATE:java.sql.Date,
+  CARRIER: String,
+  TAIL_NUM: String,
+  FL_NUM: String,
+  ORIG_ID: Int,
+  ORIG_SEQ_ID: Int,
+  ORIGIN: String,
+  DEST_AP_ID: Int,
+  DEST: String,
+  DEP_TIME: java.sql.Date,
+  DEP_DELAY_NEW: Double,
+  ARR_TIME: java.sql.Date,
+  ARR_DELAY_NEW: Double,
+  ELAPSED_TIME: Double,
+  DISTANCE: Double,
+  key: String,
+  expiry: Int
+) extends Serializable
 
 object Flight{
-	val dtf = DateTimeFormat.forPattern("yyyy-MM-dd")
-			val tf = DateTimeFormat.forPattern("yyyy-MM-dd HHmm")
+  val dtf = DateTimeFormat.forPattern("yyyy-MM-dd")
+  val tf = DateTimeFormat.forPattern("yyyy-MM-dd HHmm")
 
-			def assign(csvRow: String): Flight = {
+  def assign(csvRow: String): Flight = {
 
-					val values = csvRow.split(",")
-							var flight = new Flight(
-									values(0).toInt,
-									values(1).toInt,
-									values(2).toInt,
-									values(3).toInt,
-									new java.sql.Date(dtf.parseDateTime(values(4)).getMillis),
-									values(5),
-									values(6),
-									values(7),
-									values(8).toInt,
-									values(9).toInt,
-									values(10),
-									values(11).toInt,
-									values(12),
-									toTime(values(4), values(13)),
-									toDouble(values(14)),
-									toTime(values(4), values(15)),
-									toDouble(values(16)),
-									toDouble(values(17)),
-									toDouble(values(18)),
-									formKey(values),
-									-1
-									)
-							flight
-	}
+    val values = csvRow.split(",")
+    var flight = new Flight(
+      values(0).toInt,
+      values(1).toInt,
+      values(2).toInt,
+      values(3).toInt,
+      new java.sql.Date(dtf.parseDateTime(values(4)).getMillis),
+      values(5),
+      values(6),
+      values(7),
+      values(8).toInt,
+      values(9).toInt,
+      values(10),
+      values(11).toInt,
+      values(12),
+      toTime(values(4), values(13)),
+      toDouble(values(14)),
+      toTime(values(4), values(15)),
+      toDouble(values(16)),
+      toDouble(values(17)),
+      toDouble(values(18)),
+      formKey(values),
+      -1
+    )
+    flight
+  }
 
-	def formKey(values:Array[String]): String = {
-			val dep = formKey(values(13),
-			      values(5),
-			      values(7),
-			      values(4))
-			dep
-	}
-	
-	def formKey(depTime:String, carrier:String, flNumber:String, flDate:String): String = {
-			val dep = if (depTime.isEmpty) "XXXX" else depTime
-			carrier+flNumber+":"+flDate + ":" + dep
-	}
+  def formKey(values:Array[String]): String = {
+    val dep = formKey(values(13),
+      values(5),
+      values(7),
+      values(4))
+    dep
+  }
 
-	def toDouble(doubleString: String): Double = {
-			val number = doubleString match {
-			case "" => 0.0
-			case _ => doubleString.toDouble
-			}
-			number
-	}
+  def formKey(depTime:String, carrier:String, flNumber:String, flDate:String): String = {
+    val dep = if (depTime.isEmpty) "XXXX" else depTime
+    carrier+flNumber+":"+flDate + ":" + dep
+  }
 
-	def toTime(dateString:String, timeString: String): java.sql.Date = {
-			val time = timeString match {
-			case "" => null
-			case "2400" => new java.sql.Date(tf.parseDateTime(dateString + " 0000").getMillis)
-			case _ => new java.sql.Date(tf.parseDateTime(dateString + " " + timeString).getMillis)
-			}
-			time
-	}
+  def toDouble(doubleString: String): Double = {
+    val number = doubleString match {
+      case "" => 0.0
+      case _ => doubleString.toDouble
+    }
+    number
+  }
+
+  def toTime(dateString:String, timeString: String): java.sql.Date = {
+    val time = timeString match {
+      case "" => null
+      case "2400" => new java.sql.Date(tf.parseDateTime(dateString + " 0000").getMillis)
+      case _ => new java.sql.Date(tf.parseDateTime(dateString + " " + timeString).getMillis)
+    }
+    time
+  }
 }

--- a/src/test/scala/com/aerospike/spark/sql/ConfigTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/ConfigTest.scala
@@ -7,7 +7,7 @@ class ConfigTest extends FlatSpec {
 
   it should " create defaults" in {
     val conf = AerospikeConfig.newConfig()
-    
+
     assert(conf.port() == 3000)
     assert(conf.seedHost() == "127.0.0.1")
     assert(conf.schemaScan() == 100)
@@ -17,12 +17,12 @@ class ConfigTest extends FlatSpec {
     assert(conf.generationColumn() == "__generation")
     assert(conf.ttlColumn() == "__ttl")
   }
-  
+
   it should " create defaults with overrides" in {
-    val parameters = Map(AerospikeConfig.SeedHost -> Globals.seedHost, 
-        AerospikeConfig.Port -> 4000,
-        AerospikeConfig.NameSpace -> Globals.namespace,
-        AerospikeConfig.KeyColumn -> "_my_key") 
+    val parameters = Map(AerospikeConfig.SeedHost -> Globals.seedHost,
+      AerospikeConfig.Port -> 4000,
+      AerospikeConfig.NameSpace -> Globals.namespace,
+      AerospikeConfig.KeyColumn -> "_my_key")
     val conf = AerospikeConfig.newConfig(parameters)
 
     assert(conf.port() == 4000)
@@ -35,13 +35,13 @@ class ConfigTest extends FlatSpec {
     assert(conf.ttlColumn() == "__ttl")
     assert(conf.schemaScan() == 100)
   }
-  
-    it should " create with timeout" in {
-    val parameters = Map(AerospikeConfig.SeedHost -> Globals.seedHost, 
-        AerospikeConfig.Port -> 4000,
-        AerospikeConfig.TimeOut -> 600,
-        AerospikeConfig.NameSpace -> Globals.namespace,
-        AerospikeConfig.KeyColumn -> "_my_key") 
+
+  it should " create with timeout" in {
+    val parameters = Map(AerospikeConfig.SeedHost -> Globals.seedHost,
+      AerospikeConfig.Port -> 4000,
+      AerospikeConfig.TimeOut -> 600,
+      AerospikeConfig.NameSpace -> Globals.namespace,
+      AerospikeConfig.KeyColumn -> "_my_key")
     val conf = AerospikeConfig.newConfig(parameters)
 
     assert(conf.port() == 4000)

--- a/src/test/scala/com/aerospike/spark/sql/ListTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/ListTest.scala
@@ -40,15 +40,15 @@ class ListTest extends FlatSpec with BeforeAndAfter{
   var thingsDF: DataFrame = _
   val set = "lists"
   val listBin = "list-of-things"
-  
+
   val TEST_COUNT = 100
-  
+
   val config = AerospikeConfig.newConfig(Globals.seedHost, 3000, 1000)
-  
+
   before {
     conf = new SparkConf().setMaster("local[*]")
-        .setAppName("Aerospike Relation Tests")
-        .set("spark.driver.allowMultipleContexts", "true")
+      .setAppName("Aerospike Relation Tests")
+      .set("spark.driver.allowMultipleContexts", "true")
     sc = new SparkContext(conf)
     sqlContext = new SQLContext(sc)
 
@@ -61,97 +61,97 @@ class ListTest extends FlatSpec with BeforeAndAfter{
   }
 
   behavior of "Aerospike List"
-  
+
   it should "create test data" in {
     client = AerospikeConnection.getClient(config)
     Value.UseDoubleType = true
     val wp = new WritePolicy()
     wp.expiration = 600 // expire data in 10 minutes
-    
+
     // Create many records with values in a list
-		val rand = new Random(300);
-		for (i <- 1 to TEST_COUNT){
-			val newKey = new Key(Globals.namespace, set, s"a-record-with-a-list-$i")
-			var aList = new ArrayList[Long]();
-		  for ( j <- 1 to TEST_COUNT){
-				val newInt = rand.nextInt(200) + 250L
-				aList.add(newInt)
-		  }
-		  client.put(wp, newKey, new Bin(listBin, aList));
-		}
+    val rand = new Random(300);
+    for (i <- 1 to TEST_COUNT){
+      val newKey = new Key(Globals.namespace, set, s"a-record-with-a-list-$i")
+      var aList = new ArrayList[Long]();
+      for ( j <- 1 to TEST_COUNT){
+        val newInt = rand.nextInt(200) + 250L
+        aList.add(newInt)
+      }
+      client.put(wp, newKey, new Bin(listBin, aList));
+    }
   }
-  
+
   it should "read list data" in {
-		thingsDF = sqlContext.read.
-						format("com.aerospike.spark.sql").
-						option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", set).
-						load 
-	  thingsDF.printSchema()
-	  //thingsDF.show()
-	  
-		val result = thingsDF.take(50)
-		result.foreach { row => 
-		    val position = row.fieldIndex(listBin)
-		    val list = row.getList[Long](position)
-		    val first = list.get(0)
-		    assert(first.isInstanceOf[Long])
+    thingsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", set).
+      load
+    thingsDF.printSchema()
+    //thingsDF.show()
+
+    val result = thingsDF.take(50)
+    result.foreach { row =>
+      val position = row.fieldIndex(listBin)
+      val list = row.getList[Long](position)
+      val first = list.get(0)
+      assert(first.isInstanceOf[Long])
     }
   }
 
   it should "write list data" in {
     val schema = new StructType(Array(
-        StructField("key", StringType, nullable = false),
-        StructField("last", StringType, nullable = true),
-        StructField("first", StringType, nullable = true),
-        StructField(listBin, ArrayType(LongType,true)),
-        StructField("ttl", IntegerType, nullable = true)
-        )) 
+      StructField("key", StringType, nullable = false),
+      StructField("last", StringType, nullable = true),
+      StructField("first", StringType, nullable = true),
+      StructField(listBin, ArrayType(LongType,true)),
+      StructField("ttl", IntegerType, nullable = true)
+    ))
     val rows = Seq(
-        Row("Fraser_Malcolm","Fraser", "Malcolm", Array(1975L, 1983L), 600),
-        Row("Hawke_Bob","Hawke", "Bob", Array(1983L, 1991L), 600),
-        Row("Keating_Paul","Keating", "Paul", Array(1991L, 1996L), 600), 
-        Row("Howard_John","Howard", "John", Array(1996L, 2007L), 600), 
-        Row("Rudd_Kevin","Rudd", "Kevin", Array(2007L, 2010L), 600), 
-        Row("Gillard_Julia","Gillard", "Julia", List(2010L, 2013L), 600), 
-        Row("Abbott_Tony","Abbott", "Tony", Array(2013L, 2015L), 600), 
-        Row("Tunrbull_Malcom","Tunrbull", "Malcom", Seq(2015L, 2016L), 600)
-        )
-        
+      Row("Fraser_Malcolm","Fraser", "Malcolm", Array(1975L, 1983L), 600),
+      Row("Hawke_Bob","Hawke", "Bob", Array(1983L, 1991L), 600),
+      Row("Keating_Paul","Keating", "Paul", Array(1991L, 1996L), 600),
+      Row("Howard_John","Howard", "John", Array(1996L, 2007L), 600),
+      Row("Rudd_Kevin","Rudd", "Kevin", Array(2007L, 2010L), 600),
+      Row("Gillard_Julia","Gillard", "Julia", List(2010L, 2013L), 600),
+      Row("Abbott_Tony","Abbott", "Tony", Array(2013L, 2015L), 600),
+      Row("Tunrbull_Malcom","Tunrbull", "Malcom", Seq(2015L, 2016L), 600)
+    )
+
     val inputRDD = sc.parallelize(rows)
-    
+
     val newDF = sqlContext.createDataFrame(inputRDD, schema)
-	  
+
     newDF.write.
-        mode(SaveMode.Overwrite).
-        format("com.aerospike.spark.sql").
-        option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", set).
-						option("aerospike.updateByKey", "key").
-						option("aerospike.ttlColumn", "ttl").
-        save()  
-        
+      mode(SaveMode.Overwrite).
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", set).
+      option("aerospike.updateByKey", "key").
+      option("aerospike.ttlColumn", "ttl").
+      save()
+
     var poliKey = new Key(Globals.namespace, set, "Fraser_Malcolm")
     val fraser = client.get(null, poliKey)
     assert(fraser != null)
     val fraserList = fraser.getList(listBin)
     assert(fraserList.get(0) == 1975L)
-    
+
     poliKey = new Key(Globals.namespace, set, "Gillard_Julia")
     val gillard = client.get(null, poliKey)
     assert(gillard != null)
     val gillardList = gillard.getList(listBin)
-	  assert(gillardList.get(1) == 2013L)
+    assert(gillardList.get(1) == 2013L)
 
     poliKey = new Key(Globals.namespace, set, "Tunrbull_Malcom")
     val tunrbull = client.get(null, poliKey)
     assert(tunrbull != null)
     val tunrbullList = tunrbull.getList(listBin)
-	  assert(tunrbullList.get(1) == 2016L)
+    assert(tunrbullList.get(1) == 2016L)
   }
 
 

--- a/src/test/scala/com/aerospike/spark/sql/ListTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/ListTest.scala
@@ -1,18 +1,14 @@
 package com.aerospike.spark.sql
 
-import java.util.ArrayList
+import java.util
 
 import scala.util.Random
-
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.ArrayType
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.types.LongType
@@ -21,15 +17,11 @@ import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FlatSpec
-
 import com.aerospike.client.AerospikeClient
 import com.aerospike.client.Bin
 import com.aerospike.client.Key
 import com.aerospike.client.Value
 import com.aerospike.client.policy.WritePolicy
-
-
-import collection.JavaConverters._
 
 
 class ListTest extends FlatSpec with BeforeAndAfter{
@@ -51,7 +43,7 @@ class ListTest extends FlatSpec with BeforeAndAfter{
       .set("spark.driver.allowMultipleContexts", "true")
     sc = new SparkContext(conf)
     sqlContext = new SQLContext(sc)
-
+    createTestData()
   }
 
   after {
@@ -60,26 +52,26 @@ class ListTest extends FlatSpec with BeforeAndAfter{
     }
   }
 
-  behavior of "Aerospike List"
-
-  it should "create test data" in {
+  def createTestData(): Unit = {
     client = AerospikeConnection.getClient(config)
     Value.UseDoubleType = true
     val wp = new WritePolicy()
     wp.expiration = 600 // expire data in 10 minutes
 
     // Create many records with values in a list
-    val rand = new Random(300);
+    val rand = new Random(300)
     for (i <- 1 to TEST_COUNT){
       val newKey = new Key(Globals.namespace, set, s"a-record-with-a-list-$i")
-      var aList = new ArrayList[Long]();
-      for ( j <- 1 to TEST_COUNT){
+      val aList = new util.ArrayList[Long]()
+      for ( j <- 1 to TEST_COUNT) {
         val newInt = rand.nextInt(200) + 250L
         aList.add(newInt)
       }
-      client.put(wp, newKey, new Bin(listBin, aList));
+      client.put(wp, newKey, new Bin(listBin, aList))
     }
   }
+
+  behavior of "Aerospike List"
 
   it should "read list data" in {
     thingsDF = sqlContext.read.
@@ -106,7 +98,7 @@ class ListTest extends FlatSpec with BeforeAndAfter{
       StructField("key", StringType, nullable = false),
       StructField("last", StringType, nullable = true),
       StructField("first", StringType, nullable = true),
-      StructField(listBin, ArrayType(LongType,true)),
+      StructField(listBin, ArrayType(LongType, containsNull = true)),
       StructField("ttl", IntegerType, nullable = true)
     ))
     val rows = Seq(
@@ -153,6 +145,4 @@ class ListTest extends FlatSpec with BeforeAndAfter{
     val tunrbullList = tunrbull.getList(listBin)
     assert(tunrbullList.get(1) == 2016L)
   }
-
-
 }

--- a/src/test/scala/com/aerospike/spark/sql/ListTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/ListTest.scala
@@ -3,11 +3,7 @@ package com.aerospike.spark.sql
 import java.util
 
 import scala.util.Random
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types.ArrayType
 import org.apache.spark.sql.types.IntegerType
@@ -24,32 +20,17 @@ import com.aerospike.client.Value
 import com.aerospike.client.policy.WritePolicy
 
 
-class ListTest extends FlatSpec with BeforeAndAfter{
+class ListTest extends FlatSpec with BeforeAndAfter with SparkTest {
+
+  val config = AerospikeConfig.newConfig(Globals.seedHost, 3000, 1000)
   var client: AerospikeClient = _
-  var conf: SparkConf = _
-  var sc:SparkContext = _
-  var sqlContext: SQLContext = _
-  var thingsDF: DataFrame = _
   val set = "lists"
   val listBin = "list-of-things"
 
   val TEST_COUNT = 100
 
-  val config = AerospikeConfig.newConfig(Globals.seedHost, 3000, 1000)
-
   before {
-    conf = new SparkConf().setMaster("local[*]")
-      .setAppName("Aerospike Relation Tests")
-      .set("spark.driver.allowMultipleContexts", "true")
-    sc = new SparkContext(conf)
-    sqlContext = new SQLContext(sc)
     createTestData()
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
   }
 
   def createTestData(): Unit = {
@@ -74,7 +55,7 @@ class ListTest extends FlatSpec with BeforeAndAfter{
   behavior of "Aerospike List"
 
   it should "read list data" in {
-    thingsDF = sqlContext.read.
+    val thingsDF = sqlContext.read.
       format("com.aerospike.spark.sql").
       option("aerospike.seedhost", Globals.seedHost).
       option("aerospike.port", Globals.port.toString).

--- a/src/test/scala/com/aerospike/spark/sql/MapTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/MapTest.scala
@@ -44,19 +44,19 @@ class MapTest extends FlatSpec with BeforeAndAfter{
   var thingsDF: DataFrame = _
   val set = "maps"
   val mapBin = "map-of-things"
-  
+
   val TEST_COUNT = 100
-  
+
   val config = AerospikeConfig.newConfig(Globals.seedHost, 3000, 1000)
-  
+
   before {
     conf = new SparkConf().setMaster("local[*]")
-        .setAppName("Aerospike Relation Tests")
-        .set("spark.driver.allowMultipleContexts", "true")
+      .setAppName("Aerospike Relation Tests")
+      .set("spark.driver.allowMultipleContexts", "true")
     sc = new SparkContext(conf)
     sqlContext = new SQLContext(sc)
 
-    
+
   }
 
   after {
@@ -64,105 +64,105 @@ class MapTest extends FlatSpec with BeforeAndAfter{
       sc.stop()
     }
   }
-  
-   behavior of "Aerospike Map"
-   
-     it should "create test data" in {
+
+  behavior of "Aerospike Map"
+
+  it should "create test data" in {
     client = AerospikeConnection.getClient(config)
     Value.UseDoubleType = true
     val wp = new WritePolicy()
     wp.expiration = 600 // expire data in 10 minutes
-    
+
     // Create many records with values in a map
-		val rand = new Random(300);
-		for (i <- 1 to TEST_COUNT){
-			val newKey = new Key(Globals.namespace, set, s"a-record-with-a-map-$i")
-			var aMap = new HashMap[String, Long]();
-		  for ( j <- 1 to TEST_COUNT){
-				val newInt = rand.nextInt(200) + 250L
-				aMap.put(s"index-$j", newInt)
-		  }
-		  println(aMap)
-		  client.put(wp, newKey, new Bin(mapBin, aMap));
-		}
+    val rand = new Random(300);
+    for (i <- 1 to TEST_COUNT){
+      val newKey = new Key(Globals.namespace, set, s"a-record-with-a-map-$i")
+      var aMap = new HashMap[String, Long]();
+      for ( j <- 1 to TEST_COUNT){
+        val newInt = rand.nextInt(200) + 250L
+        aMap.put(s"index-$j", newInt)
+      }
+      println(aMap)
+      client.put(wp, newKey, new Bin(mapBin, aMap));
+    }
   }
-  
+
   it should "read map data" in {
-		thingsDF = sqlContext.read.
-						format("com.aerospike.spark.sql").
-						option("aerospike.seedhost", Globals.seedHost).
-						option("aerospike.port", Globals.port.toString).
-						option("aerospike.namespace", Globals.namespace).
-						option("aerospike.set", set).
-						load 
-	  thingsDF.printSchema()
-	  //thingsDF.show()
-	  
-	  val result = thingsDF.take(50)
-	  result.foreach { row => 
-  	  val position = row.fieldIndex(mapBin)
-  	  val map = row.getMap[String, Long](position)
-  	  if ( map.contains("index-9")){
-  		  val first = map.getOrElse("index-9", -1L)
-  				  assert(first != -1)
-	    } else if ( map.contains("from")){
-  		  val first = map.getOrElse("from", -1L)
-  				  assert(first != -1)
-	    }
-		}
+    thingsDF = sqlContext.read.
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", set).
+      load
+    thingsDF.printSchema()
+    //thingsDF.show()
+
+    val result = thingsDF.take(50)
+    result.foreach { row =>
+      val position = row.fieldIndex(mapBin)
+      val map = row.getMap[String, Long](position)
+      if ( map.contains("index-9")){
+        val first = map.getOrElse("index-9", -1L)
+        assert(first != -1)
+      } else if ( map.contains("from")){
+        val first = map.getOrElse("from", -1L)
+        assert(first != -1)
+      }
+    }
   }
 
   it should "write map data" in {
     val schema = new StructType(Array(
-        StructField("key", StringType, nullable = false),
-        StructField("last", StringType, nullable = true),
-        StructField("first", StringType, nullable = true),
-        StructField(mapBin, MapType(StringType, LongType)),
-        StructField("ttl", IntegerType, nullable = true)
-        )) 
+      StructField("key", StringType, nullable = false),
+      StructField("last", StringType, nullable = true),
+      StructField("first", StringType, nullable = true),
+      StructField(mapBin, MapType(StringType, LongType)),
+      StructField("ttl", IntegerType, nullable = true)
+    ))
     val rows = Seq(
-        Row("Fraser_Malcolm","Fraser", "Malcolm", Map("from" -> 1975L, "to" -> 1983L), 600),
-        Row("Hawke_Bob","Hawke", "Bob", Map("from" -> 1983L, "to" -> 1991L), 600),
-        Row("Keating_Paul","Keating", "Paul", Map("from" -> 1991L, "to" -> 1996L), 600), 
-        Row("Howard_John","Howard", "John", Map("from" -> 1996L, "to" -> 2007L), 600), 
-        Row("Rudd_Kevin","Rudd", "Kevin", Map("from" -> 2007L, "to" -> 2010L), 600), 
-        Row("Gillard_Julia","Gillard", "Julia", Map("from" -> 2010L, "to" -> 2013L), 600), 
-        Row("Abbott_Tony","Abbott", "Tony", Map("from" -> 2013L, "to" -> 2015L), 600), 
-        Row("Tunrbull_Malcom","Tunrbull", "Malcom", Map("from" -> 2015L, "to" ->  2016L), 600)
-        )
-        
+      Row("Fraser_Malcolm","Fraser", "Malcolm", Map("from" -> 1975L, "to" -> 1983L), 600),
+      Row("Hawke_Bob","Hawke", "Bob", Map("from" -> 1983L, "to" -> 1991L), 600),
+      Row("Keating_Paul","Keating", "Paul", Map("from" -> 1991L, "to" -> 1996L), 600),
+      Row("Howard_John","Howard", "John", Map("from" -> 1996L, "to" -> 2007L), 600),
+      Row("Rudd_Kevin","Rudd", "Kevin", Map("from" -> 2007L, "to" -> 2010L), 600),
+      Row("Gillard_Julia","Gillard", "Julia", Map("from" -> 2010L, "to" -> 2013L), 600),
+      Row("Abbott_Tony","Abbott", "Tony", Map("from" -> 2013L, "to" -> 2015L), 600),
+      Row("Tunrbull_Malcom","Tunrbull", "Malcom", Map("from" -> 2015L, "to" ->  2016L), 600)
+    )
+
     val inputRDD = sc.parallelize(rows)
-    
+
     val newDF = sqlContext.createDataFrame(inputRDD, schema)
-	  
+
     newDF.write.
-        mode(SaveMode.Overwrite).
-        format("com.aerospike.spark.sql").
-        option("aerospike.seedhost", Globals.seedHost).
-				option("aerospike.port", Globals.port.toString).
-				option("aerospike.namespace", Globals.namespace).
-				option("aerospike.set", set).
-				option("aerospike.updateByKey", "key").
-				option("aerospike.ttlColumn", "ttl").
-        save()  
-        
+      mode(SaveMode.Overwrite).
+      format("com.aerospike.spark.sql").
+      option("aerospike.seedhost", Globals.seedHost).
+      option("aerospike.port", Globals.port.toString).
+      option("aerospike.namespace", Globals.namespace).
+      option("aerospike.set", set).
+      option("aerospike.updateByKey", "key").
+      option("aerospike.ttlColumn", "ttl").
+      save()
+
     var poliKey = new Key(Globals.namespace, set, "Fraser_Malcolm")
     val fraser = client.get(null, poliKey)
     assert(fraser != null)
     val fraserMap = fraser.getMap(mapBin)
     assert(fraserMap.get("from") == 1975L)
-    
+
     poliKey = new Key(Globals.namespace, set, "Gillard_Julia")
     val gillard = client.get(null, poliKey)
     assert(gillard != null)
     val gillardMap = gillard.getMap(mapBin)
-	  assert(gillardMap.get("to") == 2013L)
+    assert(gillardMap.get("to") == 2013L)
 
     poliKey = new Key(Globals.namespace, set, "Tunrbull_Malcom")
     val tunrbull = client.get(null, poliKey)
     assert(tunrbull != null)
     val tunrbullMap = tunrbull.getMap(mapBin)
-	  assert(tunrbullMap.get("to") == 2016L)
+    assert(tunrbullMap.get("to") == 2016L)
   }
 
 }

--- a/src/test/scala/com/aerospike/spark/sql/MapTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/MapTest.scala
@@ -2,9 +2,6 @@ package com.aerospike.spark.sql
 
 import java.util
 
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.scalatest.FlatSpec
 import com.aerospike.client.AerospikeClient
@@ -23,35 +20,18 @@ import com.aerospike.client.policy.WritePolicy
 
 import scala.util.Random
 
-import org.apache.spark.sql.SQLContext
 
+class MapTest extends FlatSpec with BeforeAndAfter with SparkTest {
 
-class MapTest extends FlatSpec with BeforeAndAfter{
+  val config = AerospikeConfig.newConfig(Globals.seedHost, 3000, 1000)
   var client: AerospikeClient = _
-  var conf: SparkConf = _
-  var sc:SparkContext = _
-  var sqlContext: SQLContext = _
-  var thingsDF: DataFrame = _
   val set = "maps"
   val mapBin = "map-of-things"
 
   val TEST_COUNT = 100
 
-  val config = AerospikeConfig.newConfig(Globals.seedHost, 3000, 1000)
-
   before {
-    conf = new SparkConf().setMaster("local[*]")
-      .setAppName("Aerospike Relation Tests")
-      .set("spark.driver.allowMultipleContexts", "true")
-    sc = new SparkContext(conf)
-    sqlContext = new SQLContext(sc)
     createTestData()
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
   }
 
   def createTestData(): Unit = {
@@ -77,7 +57,7 @@ class MapTest extends FlatSpec with BeforeAndAfter{
   behavior of "Aerospike Map"
 
   it should "read map data" in {
-    thingsDF = sqlContext.read.
+    val thingsDF = sqlContext.read.
       format("com.aerospike.spark.sql").
       option("aerospike.seedhost", Globals.seedHost).
       option("aerospike.port", Globals.port.toString).

--- a/src/test/scala/com/aerospike/spark/sql/MapTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/MapTest.scala
@@ -1,39 +1,29 @@
 package com.aerospike.spark.sql
+
+import java.util
+
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.SaveMode
-
 import org.scalatest.FlatSpec
-
 import com.aerospike.client.AerospikeClient
 import com.aerospike.client.Bin
 import com.aerospike.client.Key
 import com.aerospike.client.Value
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.types.ArrayType
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.types.MapType
-import org.apache.spark.sql.functions.lit
 import org.scalatest.BeforeAndAfter
 import org.apache.spark.sql.types.IntegerType
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.DateTime
 import org.apache.spark.sql.SaveMode
-
-import org.apache.spark.sql.functions._
 import com.aerospike.client.policy.WritePolicy
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Random
-import java.util.ArrayList
-import org.apache.spark.sql.SQLContext
 
-import collection.JavaConversions._
-import java.util.HashMap
+import scala.util.Random
+
+import org.apache.spark.sql.SQLContext
 
 
 class MapTest extends FlatSpec with BeforeAndAfter{
@@ -55,8 +45,7 @@ class MapTest extends FlatSpec with BeforeAndAfter{
       .set("spark.driver.allowMultipleContexts", "true")
     sc = new SparkContext(conf)
     sqlContext = new SQLContext(sc)
-
-
+    createTestData()
   }
 
   after {
@@ -65,27 +54,27 @@ class MapTest extends FlatSpec with BeforeAndAfter{
     }
   }
 
-  behavior of "Aerospike Map"
-
-  it should "create test data" in {
+  def createTestData(): Unit = {
     client = AerospikeConnection.getClient(config)
     Value.UseDoubleType = true
     val wp = new WritePolicy()
     wp.expiration = 600 // expire data in 10 minutes
 
     // Create many records with values in a map
-    val rand = new Random(300);
+    val rand = new Random(300)
     for (i <- 1 to TEST_COUNT){
       val newKey = new Key(Globals.namespace, set, s"a-record-with-a-map-$i")
-      var aMap = new HashMap[String, Long]();
+      val aMap = new util.HashMap[String, Long]()
       for ( j <- 1 to TEST_COUNT){
         val newInt = rand.nextInt(200) + 250L
         aMap.put(s"index-$j", newInt)
       }
-      println(aMap)
-      client.put(wp, newKey, new Bin(mapBin, aMap));
+      //println(aMap)
+      client.put(wp, newKey, new Bin(mapBin, aMap))
     }
   }
+
+  behavior of "Aerospike Map"
 
   it should "read map data" in {
     thingsDF = sqlContext.read.
@@ -164,5 +153,4 @@ class MapTest extends FlatSpec with BeforeAndAfter{
     val tunrbullMap = tunrbull.getMap(mapBin)
     assert(tunrbullMap.get("to") == 2016L)
   }
-
 }

--- a/src/test/scala/com/aerospike/spark/sql/QueyEngineTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/QueyEngineTest.scala
@@ -22,154 +22,154 @@ import com.aerospike.client.policy.WritePolicy
 
 class QueyEngineTest extends FlatSpec{
 
-  
-	val ages = Array(25,26,27,28,29)
-			val colours = Array("blue","red","yellow","green","orange")
-			val animals = Array("cat","dog","mouse","snake","lion")
-			
-			val wp = new WritePolicy()
-	    wp.expiration = 600
 
-			var config: AerospikeConfig = _
+  val ages = Array(25,26,27,28,29)
+  val colours = Array("blue","red","yellow","green","orange")
+  val animals = Array("cat","dog","mouse","snake","lion")
 
-			behavior of "QueryEngine from Scala"
+  val wp = new WritePolicy()
+  wp.expiration = 600
 
-			it should "Get a client from cache" in {
-				config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 20000)
-				val client = AerospikeConnection.getClient(config)
-			}
+  var config: AerospikeConfig = _
 
-			it should "Get 3 clients and ensure ther are the same" in {
-				val client1 = AerospikeConnection.getClient(config)
-						val client2 = AerospikeConnection.getClient(config)
-						assert(client1 == client2)
-						val client3 = AerospikeConnection.getClient(config)
-						assert(client1 == client3)
-			}
+  behavior of "QueryEngine from Scala"
 
-			it should "Get a query engine from cache" in {
-				val qe = AerospikeConnection.getQueryEngine(config)
-			}
+  it should "Get a client from cache" in {
+    config = AerospikeConfig.newConfig(Globals.seedHost, Globals.port, 20000)
+    val client = AerospikeConnection.getClient(config)
+  }
 
-			it should "Insert data" in {
-				val cl = AerospikeConnection.getClient(config)
+  it should "Get 3 clients and ensure ther are the same" in {
+    val client1 = AerospikeConnection.getClient(config)
+    val client2 = AerospikeConnection.getClient(config)
+    assert(client1 == client2)
+    val client3 = AerospikeConnection.getClient(config)
+    assert(client1 == client3)
+  }
 
-						var i = 0
-						for (x <- 1 to 100){
-							val name = new Bin("name", "name:" + i);
-							val age = new Bin("age", ages(i));
-							val colour = new Bin("color", colours(i));
-							val animal = new Bin("animal", animals(i));
-							val key = new Key(Globals.namespace, "selector", "selector-test:"+ x)
-									cl.put(null, key, name, age, colour, animal)
-									i += 1
-									if ( i == 5)
-										i = 0
-						}
-			}
+  it should "Get a query engine from cache" in {
+    val qe = AerospikeConnection.getQueryEngine(config)
+  }
 
-			it should "Select data" in {
-				val qe = AerospikeConnection.getQueryEngine(config)
-				val stmt = new Statement()
-				stmt.setNamespace(Globals.namespace)
-				stmt.setSetName("selector")
-				var it = qe.select(stmt)
-				for (row <- it) {
+  it should "Insert data" in {
+    val cl = AerospikeConnection.getClient(config)
+
+    var i = 0
+    for (x <- 1 to 100){
+      val name = new Bin("name", "name:" + i);
+      val age = new Bin("age", ages(i));
+      val colour = new Bin("color", colours(i));
+      val animal = new Bin("animal", animals(i));
+      val key = new Key(Globals.namespace, "selector", "selector-test:"+ x)
+      cl.put(null, key, name, age, colour, animal)
+      i += 1
+      if ( i == 5)
+        i = 0
+    }
+  }
+
+  it should "Select data" in {
+    val qe = AerospikeConnection.getQueryEngine(config)
+    val stmt = new Statement()
+    stmt.setNamespace(Globals.namespace)
+    stmt.setSetName("selector")
+    var it = qe.select(stmt)
+    for (row <- it) {
+      val key = row.key
+      val rec = row.record
+      print(".")
+    }
+    println
+    it.close()
+  }
+  it should "run concurrent selects" in {
+
+    var threads = new ListBuffer[Thread]()
+    for (i <- 1 to 50) {
+      val thread = new Thread {
+        override def run {
+
+          val qe = AerospikeConnection.getQueryEngine(config)
+          val stmt = new Statement()
+          stmt.setNamespace(Globals.namespace)
+          stmt.setSetName("selector")
+          println("\tStarted query " + i)
+          var it = qe.select(stmt)
+          var  count = 0
+          try {
+            while (it.hasNext()){
+              val keyRecord = it.next()
+              val key = keyRecord.key
+              val record = keyRecord.record
+              count = count + 1
+            }
+          } catch {
+            case ae:AerospikeException => println(ae)
+            case e:Exception => println(e)
+          }
+          finally {
+            it.close()
+          }
+          println(s"\tCompleted Query $i with $count records")
+
+        }
+
+      }
+      thread.start
+      threads += thread
+    }
+    for (t <- threads)
+      t.join()
+
+  }
+  it should "Select data by node" in {
+    val nodes = AerospikeConnection.getClient(config).getNodes
+
+    var threads = new ListBuffer[Thread]()
+    for (i <- 0 to nodes.length-1) {
+      val thread = new Thread {
+        override def run {
+          val qe = AerospikeConnection.getQueryEngine(config)
+          val stmt = new Statement()
+          stmt.setNamespace(Globals.namespace)
+          stmt.setSetName("selector")
+          println("\tStarted partition " + i)
+          var it = qe.select(stmt, false, nodes(i))
+          var  count = 0
+          for (row <- it) {
             val key = row.key
             val rec = row.record
-            print(".")
+            count = count + 1
+          }
+
+          it.close()
+          println(s"\tCompleted partition $i with $count records")
         }
-				println
-				it.close()
-			}
-			it should "run concurrent selects" in {
+      }
+      thread.start
+      threads += thread
+    }
+    for (t <- threads)
+      t.join()
 
-			  var threads = new ListBuffer[Thread]()
-				for (i <- 1 to 50) {
-					val thread = new Thread {
-						override def run {
-							
-							val qe = AerospikeConnection.getQueryEngine(config)
-							val stmt = new Statement()
-							stmt.setNamespace(Globals.namespace)
-							stmt.setSetName("selector")
-							println("\tStarted query " + i)
-							var it = qe.select(stmt)
-							var  count = 0
-							try {
-							while (it.hasNext()){
-								val keyRecord = it.next()
-										val key = keyRecord.key
-										val record = keyRecord.record
-										count = count + 1
-							}
-							} catch {
-							  case ae:AerospikeException => println(ae)
-							  case e:Exception => println(e)
-							} 
-							finally {
-							  it.close()
-							}
-							println(s"\tCompleted Query $i with $count records")
-
-						}
-
-					}
-				thread.start
-				threads += thread
-				}
-			  for (t <- threads)
-            t.join()
-			  
-			}
-			it should "Select data by node" in {
-			  val nodes = AerospikeConnection.getClient(config).getNodes
-				
-				var threads = new ListBuffer[Thread]()
-				for (i <- 0 to nodes.length-1) {
-				  val thread = new Thread {
-						override def run {
-						  val qe = AerospikeConnection.getQueryEngine(config)
-				      val stmt = new Statement()
-				      stmt.setNamespace(Globals.namespace)
-				      stmt.setSetName("selector")
-						  println("\tStarted partition " + i)
-  				    var it = qe.select(stmt, false, nodes(i))
-  				    var  count = 0
-      				for (row <- it) {
-                  val key = row.key
-                  val rec = row.record
-                  count = count + 1
-              }
-      				
-      				it.close()
-      				println(s"\tCompleted partition $i with $count records")
-						}
-				}
-				thread.start
-				threads += thread
-			}
-      for (t <- threads)
-            t.join()
-			  
-			}
+  }
 
 
-			it should "clean up because it's mother doesn't work here" in {
-				val cl = AerospikeConnection.getClient(config)
+  it should "clean up because it's mother doesn't work here" in {
+    val cl = AerospikeConnection.getClient(config)
 
-						var i = 0
-						for (x <- 1 to 100){
-							val name = new Bin("name", "name:" + i);
-							val age = new Bin("age", ages(i));
-							val colour = new Bin("color", colours(i));
-							val animal = new Bin("animal", animals(i));
-							val key = new Key(Globals.namespace, "selector", "selector-test:"+ x)
-									cl.delete(null, key)
-									i += 1
-									if ( i == 5)
-										i = 0
-						}
-			}
+    var i = 0
+    for (x <- 1 to 100){
+      val name = new Bin("name", "name:" + i);
+      val age = new Bin("age", ages(i));
+      val colour = new Bin("color", colours(i));
+      val animal = new Bin("animal", animals(i));
+      val key = new Key(Globals.namespace, "selector", "selector-test:"+ x)
+      cl.delete(null, key)
+      i += 1
+      if ( i == 5)
+        i = 0
+    }
+  }
 
 }

--- a/src/test/scala/com/aerospike/spark/sql/SparkTest.scala
+++ b/src/test/scala/com/aerospike/spark/sql/SparkTest.scala
@@ -1,0 +1,30 @@
+ package com.aerospike.spark.sql
+
+ import org.apache.spark.SparkContext
+ import org.apache.spark.sql.{SQLContext, SparkSession}
+ import org.scalatest.{BeforeAndAfterAll, Suite}
+
+ trait SparkTest extends BeforeAndAfterAll { self: Suite =>
+
+   var sc: SparkContext = _
+   var session: SparkSession = _
+   var sqlContext: SQLContext = _
+
+   override def beforeAll(): Unit = {
+     super.beforeAll()
+     session = SparkSession.builder()
+       .master("local[*]")
+       .appName("Aerospike Tests")
+       .config("spark.ui.enabled", "false")
+       .getOrCreate()
+     sc = session.sparkContext
+     sqlContext = session.sqlContext
+   }
+
+   override def afterAll(): Unit = {
+     if (session != null) {
+       session.stop()
+     }
+     super.afterAll()
+   }
+ }


### PR DESCRIPTION
Hi,
sorry in advance, this is a massive PR.
I upgraded to use Spark 2.0 but before that, I needed to reformat the sources, somehow there are tabs, 2 and 4 spaces intermixed. I also got rid of the unnecessary mutable state. 
I didn't squash my commits and left them as logical units, so it's easier for you to trace down what changed.

Also upgraded to Scala 2.11, which is the new default for Spark 2.0 but added cross compile capabilities to `build.sbt`
Spark 2.0 made the logging package private, that's why I had to introduce `scala-logging`.
